### PR TITLE
fix: 未启用`openPhiPluginApi`导致`sessionToken`未定义

### DIFF
--- a/model/send.js
+++ b/model/send.js
@@ -39,7 +39,7 @@ class send {
     async getsave_result(e, ver, send = true) {
 
         let user_save = null
-
+        let sessionToken = null
         if (Config.getUserCfg('config', 'openPhiPluginApi')) {
             try {
                 user_save = await getUpdateSave.getNewSaveFromApi(e)
@@ -48,7 +48,7 @@ class send {
                 /**如果是没有绑定过就执行绑定 */
                 if (err.message == '缺少 phigrosToken 参数') {
                     try {
-                        let sessionToken = await getSave.get_user_token(e.user_id)
+                        sessionToken = await getSave.get_user_token(e.user_id)
                         if (!sessionToken) {
                             if (send) {
                                 this.send_with_At(e, `请先绑定sessionToken哦！\n如果不知道自己的sessionToken可以尝试扫码绑定嗷！\n获取二维码：/${Config.getUserCfg('config', 'cmdhead')} bind qrcode\n帮助：/${Config.getUserCfg('config', 'cmdhead')} tk help\n格式：/${Config.getUserCfg('config', 'cmdhead')} bind <sessionToken>`)
@@ -63,6 +63,9 @@ class send {
                     }
                 }
             }
+        }
+        else {
+            sessionToken = await getSave.get_user_token(e.user_id)
         }
 
         if (!sessionToken) {


### PR DESCRIPTION
在昨天的 Commit `b957e16` 中，[`send.js` 引入了一次破坏性更改](https://github.com/Catrong/phi-plugin/commit/b957e16f29f332b30059c307f7368cfe603ff5c0#diff-bb78e8263284725c1621b8caea694849ebb52ac33c110b7e911eae262ac5661aL68)。这一个更改导致未开启并配置 `openPhiPluginApi` 的bot在获取服务器本地存档时出现 `sessionToken` 的未定义异常。

这个PR将 `sessionToken` 变量定义挪到函数头部，并对未开启 `openPhiPluginApi` 的情形进行了本地存档读取支持。