### PR TITLE
修复chart命令部分情况下曲目匹配失败的问题

### DIFF
--- a/components/baseClass.js
+++ b/components/baseClass.js
@@ -127,7 +127,7 @@ export default class phiPluginBase extends plugin {
         case 'rank': {
           let rank = /** @type {levelKind} */((msg.match(/\b(EZ|HD|IN|AT)\b/i)?.[1] || 'IN').toUpperCase())
           optObj[opt] = rank;
-          msg = msg.replace(/\b(EZ|HD|IN|AT)\b/i, '')
+          msg = msg.replace(/\b(EZ|HD|IN|AT)\b/i, '').trim()
           break;
         }
       }


### PR DESCRIPTION
/chart +++ AT会提示“未找到“+++ ”的曲目信息”，因为多出的空格导致匹配失败

因此对msg进行trim处理，确保不会因为空格导致曲目无法匹配