### PR TITLE
修复特定命令头下fc30/p30/x30参数异常的bug

### DIFF
--- a/apps/b19.js
+++ b/apps/b19.js
@@ -243,9 +243,8 @@ export class phib19 extends phiPluginBase {
         }
 
 
-        let numMsg = e.msg.match(/^.*?(p|x|fc)[0-9]+/i)?.[0]
-
-        let nnum = Number(numMsg?.replace(/^.*?(p|x|fc)/i, '') || 33)
+        let match = e.msg.match(/^.*?(p|x|fc)\s*([0-9]+)/i)
+        let nnum = Number(match?.[2] || 33)
         if (!nnum) {
             nnum = 33
         }
@@ -253,7 +252,7 @@ export class phib19 extends phiPluginBase {
         nnum = Math.max(nnum, 33)
         nnum = Math.min(nnum, Config.getUserCfg('config', 'B19MaxNum'))
 
-        let bksong = e.msg.replace(/^.*?(p|x|fc)[0-9]+\s*/i, '')
+        let bksong = e.msg.replace(/^.*?(p|x|fc)\s*[0-9]+\s*/i, '')
 
         if (bksong) {
             let songId = getInfo.fuzzysongsnick(bksong)[0]
@@ -274,7 +273,7 @@ export class phib19 extends phiPluginBase {
         let save_b19;
         let spInfo = [];
 
-        const type = e.msg.match(/^.*?(p|x|fc)([0-9]+)/i)?.[1].toLowerCase();
+        const type = e.msg.match(/^.*?(p|x|fc)\s*([0-9]+)/i)?.[1].toLowerCase();
         switch (type) {
             case 'p': {
                 save_b19 = await save.getBestWithLimit(nnum, [{ type: 'acc', value: [100, 100] }])


### PR DESCRIPTION
当配置的`cmdhead`包含"p/fc/x"时，会导致`p30`、`fc30`、`x30`功能的参数出现异常。尤其是默认配置的命令头"phi"即可复现该问题。
具体表现为：
1. 使用`/phi fc 30`会返回`p30`的图片
2. `cmdhead`包含"p/fc/x"时，无论输入数字是多少都只会返回30个条目

### 根本原因

问题出在`apps/b19.js`的`p30`函数中，消息解析正则有两个关联问题：

#### 问题 1：类型和数量之间不允许有空格

行`246/277`的提取正则要求`(p|x|fc)`后立即跟数字`[0-9]+`，但实际消息`/phi fc 30`中间有空格。这导致提取失败，`type`为`undefined`，落到`default`分支 → "All Perfect Mode"。

#### 问题 2：replace 正则被 phi 中的 p 欺骗（cmdhead 特定问题）

1. 行`248`用`replace(/^.*?(p|x|fc)/i, '') `提取数字。因为`.*?`是非贪婪的，当`cmdhead=phi`时，正则`(p|x|fc)`会匹配到`phi`中的`p`（位置1），而不是`命令类型p`。`replace`只去掉了`/p`，留下`hi p 30`，`Number()`得到`NaN`。
2. 当`cmdhead`不含`p/x/fc`时，问题 2 不触发，这也是为什么「其他命令头无法复现」。

本PR对apps/b19.js做以下改动：
1. line 246: 添加`\s*`并用捕获组直接提取数字：`/^.*?(p|x|fc)\s*([0-9]+)/i`
2. line 248: 删除 — 改用`match?.[2]`直接取数字捕获组，彻底避开非贪婪`.*?`匹配到`cmdhead`的问题
3. line 256: 添加`\s*`：`/^.*?(p|x|fc)\s*[0-9]+\s*/i`
4. line 277: 添加`\s*：/^.*?(p|x|fc)\s*([0-9]+)/i`

经过本地测试，默认配置下，`/phi fc 30`、`/phifc 30`、`/phi p 30`等格式都可以正确解析类型和数量。改动对所有命令头配置兼容，不会导致其他命令头配置失效
