### PR TITLE
修复未绑定用户被 API 黑名单检查阻断

### DIFF
--- a/model/user/userCredentials.js
+++ b/model/user/userCredentials.js
@@ -302,10 +302,16 @@ export class UserCredentials {
      * @returns {Promise<boolean | null>} 禁用状态；请求失败或被忽略时返回 `null`
      */
     async getUserAPIBanStatus(options = {}) {
-        return makeRequest.getUserBan(
-            await this.platformParams(true),
-            this.endpointOptions(options),
-        )
+        const endpointOptions = this.endpointOptions(options)
+        try {
+            return await makeRequest.getUserBan(
+                await this.platformParams(true),
+                endpointOptions,
+            )
+        } catch (error) {
+            if (makeRequest.shouldIgnoreError(error, endpointOptions)) return null
+            throw error
+        }
     }
 
     /**

--- a/tests/makeRequestHandling.test.js
+++ b/tests/makeRequestHandling.test.js
@@ -88,3 +88,31 @@ test('UserCredentials endpoint methods forward ignoreUnboundError and use the ty
         platform.sendWithAt = originalSend
     }
 })
+
+test('UserCredentials can ignore missing local credentials before making the API request', async () => {
+    let calls = 0
+    const store = {
+        getSessionToken: async () => undefined,
+        getApiId: async () => undefined,
+    }
+    const originalRequest = phiApiClient.request
+    phiApiClient.request = async () => { calls += 1 }
+    try {
+        const credentials = UserCredentials.fromEvent(event, {
+            store: /** @type {any} */ (store),
+        })
+
+        assert.equal(
+            await credentials.getUserAPIBanStatus({ ignoreUnboundError: true }),
+            null,
+        )
+        assert.equal(calls, 0)
+        await assert.rejects(
+            credentials.getUserAPIBanStatus(),
+            (/** @type {any} */ error) => error.code === 'binding_not_found',
+        )
+        assert.equal(calls, 0)
+    } finally {
+        phiApiClient.request = originalRequest
+    }
+})


### PR DESCRIPTION
  ## 问题

  API 黑名单前置检查调用 `getUserAPIBanStatus({ ignoreUnboundError: true })` 时，`platformParams(true)` 会在请求错误处理之外抛出 `binding_not_found`。

  因此，尚未绑定 API 凭据的用户执行 `/bind`、`/b27` 等命令时，会在前置检查阶段被直接阻断，命令没有任何回复。

  ## 修改

  - 将请求参数构建纳入 `getUserAPIBanStatus` 的错误处理范围
  - 启用 `ignoreUnboundError` 时，将未绑定状态视为无黑名单记录并返回 `null`
  - 未启用该选项时，继续保留原有的抛错行为
  - 添加回归测试，确认未绑定用户不会触发 API 请求，也不会被前置检查阻断
