### PR TITLE
fix:主题选项固定四列并支持换行

### DIFF
--- a/resources/html/setting/userSetting.art
+++ b/resources/html/setting/userSetting.art
@@ -12,7 +12,7 @@
         </div>
 
         {{each items as item}}
-        <div class="setting-group">
+        <div class="setting-group setting-{{item.key}}">
             <div class="setting-head">
                 <p class="setting-title">{{item.title}}</p>
                 <p class="setting-current">当前：{{item.currentTitle}}</p>

--- a/resources/html/setting/userSetting.css
+++ b/resources/html/setting/userSetting.css
@@ -104,6 +104,14 @@ body {
     box-sizing: border-box;
 }
 
+.setting-theme .option-row {
+    flex-wrap: wrap;
+}
+
+.setting-theme .option-card {
+    flex: 0 0 calc((100% - 30px) / 4);
+}
+
 .option-card.selected {
     border-color: #7be7ff;
     background: linear-gradient(170deg, rgb(26 81 118 / 88%), rgb(12 50 77 / 85%));


### PR DESCRIPTION
 ## 变更内容

  - 主题风格选项固定为每行 4 个
  - 主题数量超过 4 个时自动换行
  - 仅影响主题风格选项，其他用户设置布局保持不变
