### PR TITLE
feat(theme): 支持按页面配置 CSS，并修复自定义字体影响其他页面

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ pnpm install -P
 | `#phi randclg [课题总值] [难度] ([曲目定数范围])` | 随机课题 eg: /rand 40 (IN 13-15)
 | `#phi (曲绘\|ill\|Ill) xxx` | 查询phigros中某一曲目的曲绘
 | `#phi (search\|查询\|检索) <条件 值>` | 检索曲库中的曲目，支持BPM 定数 物量，条件 bpm dif cmb，值可以为区间，以 - 间隔
-| `#phi (theme\|主题) [0-2]` | 切换绘图主题，仅对 b30, update, randclg, sign, task 生效
+| `#phi (theme\|主题) [编号]` | 切换绘图主题，页面级样式按主题包配置生效
 | `#phi (myset\|个人设置)` | 查看和修改用户设置，参数为设置项名称，值支持使用序号选择，建议先查看设置项列表
 | `sign/签到` | 签到获取Notes
 | `task/我的任务` | 查看自己的任务

--- a/README_en.md
+++ b/README_en.md
@@ -128,7 +128,7 @@ Note: `#` can be replaced with `/`. Command headers are customizable.
 | `#phi randclg [total] [difficulty] ([rating range])` | Random challenge (e.g., /rand 40 (IN 13-15)) |
 | `#phi ill xxx` | View song illustration |
 | `#phi search <criteria>` | Search songs by BPM/rating/notes |
-| `#phi theme [0-2]` | Switch themes (affects b30/update/randclg/sign/task) |
+| `#phi theme [number]` | Switch themes; page styles are applied according to the theme package |
 | `#phi myset <field> <value>` | View/modify user settings, value supports selection by number (e.g., /myset theme 1) |
 | `sign/sign` | Daily check-in |
 | `task/mytasks` | View tasks |

--- a/apps/apiSetting.js
+++ b/apps/apiSetting.js
@@ -14,6 +14,7 @@ import userCredentialStore from '../model/user/userCredentialStore.js'
 import { getApiAccessState } from '../model/user/apiPermission.js'
 import fCompute from '../model/game/fCompute.js'
 import platform from '../components/platform/index.js'
+import getNotes from '../model/user/getNotes.js'
 
 
 /**@import {botEvent} from '../components/baseClass.js' */
@@ -550,6 +551,7 @@ export class phihelp extends phiPluginBase {
         * @param {Partial<Record<apiSettingKey, boolean>>} userSetting
      */
     async renderApiUserSetting(e, userSetting) {
+        const pluginData = await getNotes.getNotesData(e.user_id)
         /**
          * @param {keyof typeof USER_API_SETTING_OPTIONS} key
          * @param {string} current
@@ -580,7 +582,7 @@ export class phihelp extends phiPluginBase {
             pageDescription: '以下设置会同步到查分平台账户权限。',
             items: items,
             background: getInfo.getill(getInfo.illlist[Number((Math.random() * (getInfo.illlist.length - 1)).toFixed(0))]),
-            theme: 'default'
+            theme: pluginData?.theme || 'default'
         }, 'userSetting'))
     }
 }

--- a/apps/setting.js
+++ b/apps/setting.js
@@ -397,7 +397,7 @@ export class phihelp extends phiPluginBase {
         send.send_with_At(e, await picmodle.common(e, 'setting', {
             ...data,
             background: getInfo.getill(getInfo.illlist[Number((Math.random() * (getInfo.illlist.length - 1)).toFixed(0))]),
-            theme: 'default'
+            theme: pluginData?.theme || 'default'
         }, 'userSetting'))
         return true
     }

--- a/model/render/picmodle.js
+++ b/model/render/picmodle.js
@@ -372,13 +372,13 @@ export default await new class picmodle {
 
             Data.createDir(`data/html/${Plugin_Name}/${app}/${tpl}`, 'root')
 
-            /** 主题解析：自定义主题的模板仅作用于 b19，themeInfo 注入布局与模板（内置主题为 null，行为与现状一致） */
+            /** 主题解析：自定义模板仅作用于 B19，页面样式与公共主题信息由 themeInfo 注入布局。 */
             let tplFile = path.join(pluginResources, 'html', app, `${tpl}.art`).replace(/\\/g, '/')
             let themeInfo = null
             const themeId = params.theme
             if (themeId) {
-                const t = themeManager.getRenderInfo(themeId, resPath)
-                if (t?.tplFile && app === 'b19') tplFile = t.tplFile
+                const t = themeManager.getRenderInfo(themeId, resPath, renderPath)
+                if (t?.tplFile && renderPath === 'b19/b19') tplFile = t.tplFile
                 if (t?.themeInfo) themeInfo = t.themeInfo
             }
 

--- a/model/themeManager.js
+++ b/model/themeManager.js
@@ -33,6 +33,9 @@ const CONFLICT_IDS = new Set(['default', 'snow', 'star', 'dss2', 'topText', 'foo
 /** 主题 id 合法性 */
 const ID_RE = /^[a-zA-Z0-9_-]+$/
 
+/** 页面样式键：app 或 app/template */
+const PAGE_KEY_RE = /^[a-zA-Z0-9_-]+(?:\/[a-zA-Z0-9_-]+)?$/
+
 /** 难度色合法性（#RRGGBB / #RGB 等） */
 const COLOR_RE = /^#[0-9a-fA-F]{3,8}$/
 
@@ -43,12 +46,14 @@ const COLOR_RE = /^#[0-9a-fA-F]{3,8}$/
  * @property {string} [author] 作者
  * @property {string} [description] 描述（myset 展示）
  * @property {string} dir 主题目录绝对路径
+ * @property {string} dirName 主题目录名
  * @property {string} [font] 字体文件名
  * @property {string} [background] 背景图文件名
  * @property {Record<string, string>} [icons] 评级图标文件名映射（key 与 song.Rating 取值一致）
  * @property {Record<string, string>} [colors] 四难度基础色（AT/IN/HD/EZ）
  * @property {string} [template] b19 模板文件名
- * @property {string} [css] 样式表文件名
+ * @property {Record<string, string>} [css] 按渲染页面配置的样式表文件名
+ * @property {boolean} [legacyCss] 是否使用旧版 B19 替换样式语义
  */
 
 /**
@@ -94,7 +99,8 @@ export default await new class themeManager {
                     const dir = path.join(THEMES_DIR, dirName)
                     let isDir = false
                     try {
-                        isDir = fs.statSync(dir).isDirectory()
+                        // 主题根目录必须是实体目录，避免通过目录链接绕过资源根边界。
+                        isDir = fs.lstatSync(dir).isDirectory()
                     } catch { }
                     if (!isDir) continue
                     const entry = this.parseThemeDir(dir, dirName, themes)
@@ -158,13 +164,25 @@ export default await new class themeManager {
 
         const name = typeof yamlData.name === 'string' && yamlData.name ? yamlData.name : id
         /** @type {CustomTheme} */
-        const entry = { id, name, dir }
+        const entry = { id, name, dir, dirName }
         if (typeof yamlData.Author === 'string' && yamlData.Author) entry.author = yamlData.Author
         if (typeof yamlData.description === 'string' && yamlData.description) entry.description = yamlData.description
-        /** @type {['font', 'background', 'template', 'css']} */
-        const assetKeys = ['font', 'background', 'template', 'css']
+        /** @type {['font', 'background', 'template']} */
+        const assetKeys = ['font', 'background', 'template']
         for (const key of assetKeys) {
             if (typeof yamlData[key] === 'string' && yamlData[key]) entry[key] = yamlData[key]
+        }
+        if (typeof yamlData.css === 'string' && yamlData.css) {
+            // 旧主题包的字符串 CSS 会替换 B19 默认样式，不能改成覆盖层。
+            entry.css = { 'b19/b19': yamlData.css }
+            entry.legacyCss = true
+        } else if (yamlData.css && typeof yamlData.css === 'object') {
+            /** @type {Record<string, string>} */
+            const pageCss = {}
+            for (const [page, file] of Object.entries(yamlData.css)) {
+                if (PAGE_KEY_RE.test(page) && typeof file === 'string' && file) pageCss[page] = file
+            }
+            if (Object.keys(pageCss).length) entry.css = pageCss
         }
         if (yamlData.icon && typeof yamlData.icon === 'object') {
             /** @type {Record<string, string>} */
@@ -189,7 +207,7 @@ export default await new class themeManager {
     /**
      * 获取主题条目（内置或自定义），未知 id 返回 null
      * @param {string} [id]
-     * @returns {{id: string, name: string, dir?: string, template?: string, css?: string, font?: string, background?: string, icons?: Record<string, string>, colors?: Record<string, string>} | null}
+     * @returns {{id: string, name: string, dir?: string, dirName?: string, template?: string, css?: Record<string, string>, legacyCss?: boolean, font?: string, background?: string, icons?: Record<string, string>, colors?: Record<string, string>} | null}
      */
     getTheme(id) {
         if (!id) return null
@@ -249,36 +267,72 @@ export default await new class themeManager {
      * 内置 dss2 返回其独立模板路径（themeInfo 为 null）；未知/内置无资源返回 null
      * @param {string} id
      * @param {string} resPath 资源根路径（结尾带 /）
+     * @param {string} [page] 当前渲染目标（app/template；短键 app 会规范为 app/app）
      * @returns {{tplFile: string | null, themeInfo: any} | null}
      */
-    getRenderInfo(id, resPath) {
+    getRenderInfo(id, resPath, page = 'b19/b19') {
         if (!id) return null
         const custom = this.customThemes.get(id)
         if (custom) {
-            const baseUrl = `${resPath}html/b19/themes/${id}/`
-            /** 校验主题资源文件是否存在（值为空或文件缺失均视为不存在） */
-            /** @param {string | undefined} name */
-            const exists = (name) => {
-                if (!name) return false
-                return fs.existsSync(path.join(custom.dir, name))
+            const baseUrl = `${resPath}html/b19/themes/${custom.dirName}/`
+            const renderTarget = page.includes('/') ? page : `${page}/${page}`
+            const app = renderTarget.split('/')[0]
+            let realThemeDir
+            try {
+                realThemeDir = fs.realpathSync(custom.dir)
+            } catch {
+                return null
             }
+            /** 仅解析主题目录内的普通文件，缺失或越界资源均走默认回退。 */
+            /** @param {string | undefined} name */
+            const resolveAsset = (name) => {
+                if (!name) return null
+                const candidate = path.resolve(custom.dir, name)
+                const relative = path.relative(custom.dir, candidate)
+                if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) return null
+                try {
+                    if (!fs.lstatSync(candidate).isFile()) return null
+                    const realCandidate = fs.realpathSync(candidate)
+                    const realRelative = path.relative(realThemeDir, realCandidate)
+                    if (realRelative === '..' || realRelative.startsWith(`..${path.sep}`) || path.isAbsolute(realRelative)) return null
+                    return {
+                        file: candidate,
+                        relative: relative.replace(/\\/g, '/'),
+                    }
+                } catch {
+                    return null
+                }
+            }
+            /** @param {{relative: string}} asset */
+            const assetUrl = (asset) => baseUrl + asset.relative
             /** @type {any} */
             const themeInfo = { id: custom.id, name: custom.name, baseUrl }
-            if (exists(custom.css)) themeInfo.cssUrl = baseUrl + custom.css
-            if (exists(custom.font)) themeInfo.fontUrl = baseUrl + custom.font
-            if (exists(custom.background)) themeInfo.backgroundUrl = baseUrl + custom.background
+            const cssNames = custom.legacyCss
+                ? (renderTarget === 'b19/b19' ? [custom.css?.['b19/b19']] : [])
+                : [custom.css?.[renderTarget], custom.css?.[app]]
+            const pageCss = cssNames.map(resolveAsset).find(Boolean)
+            if (pageCss) {
+                themeInfo.cssUrl = assetUrl(pageCss)
+                themeInfo.cssMode = custom.legacyCss ? 'replace' : 'overlay'
+                // 未给当前页面配置 CSS 时保留插件原生字体。
+                const font = resolveAsset(custom.font)
+                if (font) themeInfo.fontUrl = assetUrl(font)
+            }
+            const background = resolveAsset(custom.background)
+            if (background) themeInfo.backgroundUrl = assetUrl(background)
             if (custom.icons) {
                 /** @type {Record<string, string>} */
                 const icons = {}
                 for (const [k, v] of Object.entries(custom.icons)) {
-                    if (exists(v)) icons[k] = baseUrl + v
+                    const icon = resolveAsset(v)
+                    if (icon) icons[k] = assetUrl(icon)
                 }
                 if (Object.keys(icons).length) themeInfo.icons = icons
             }
             if (custom.colors) themeInfo.colors = custom.colors
-            const template = custom.template
+            const template = resolveAsset(custom.template)
             return {
-                tplFile: template && exists(template) ? path.join(custom.dir, template).replace(/\\/g, '/') : null,
+                tplFile: template ? template.file.replace(/\\/g, '/') : null,
                 themeInfo,
             }
         }

--- a/model/themeManager.js
+++ b/model/themeManager.js
@@ -40,6 +40,12 @@ const PAGE_KEY_RE = /^[a-zA-Z0-9_-]+(?:\/[a-zA-Z0-9_-]+)?$/
 const COLOR_RE = /^#[0-9a-fA-F]{3,8}$/
 
 /**
+ * 对 URL 中由主题包控制的路径逐段编码，同时保留目录分隔符。
+ * @param {string} value
+ */
+const encodeThemeUrlPath = value => value.split('/').map(encodeURIComponent).join('/')
+
+/**
  * @typedef {object} CustomTheme 自定义主题条目（由 info.yaml 解析得到）
  * @property {string} id 主题标识
  * @property {string} name 显示名
@@ -274,7 +280,7 @@ export default await new class themeManager {
         if (!id) return null
         const custom = this.customThemes.get(id)
         if (custom) {
-            const baseUrl = `${resPath}html/b19/themes/${custom.dirName}/`
+            const baseUrl = `${resPath}html/b19/themes/${encodeURIComponent(custom.dirName)}/`
             const renderTarget = page.includes('/') ? page : `${page}/${page}`
             const app = renderTarget.split('/')[0]
             let realThemeDir
@@ -304,7 +310,7 @@ export default await new class themeManager {
                 }
             }
             /** @param {{relative: string}} asset */
-            const assetUrl = (asset) => baseUrl + asset.relative
+            const assetUrl = (asset) => baseUrl + encodeThemeUrlPath(asset.relative)
             /** @type {any} */
             const themeInfo = { id: custom.id, name: custom.name, baseUrl }
             const cssNames = custom.legacyCss

--- a/resources/html/arcgrosB19/arcgrosB19.css
+++ b/resources/html/arcgrosB19/arcgrosB19.css
@@ -580,19 +580,19 @@ p {
 }
 
 .EZ {
-    background: linear-gradient(180deg, var(--EZ) 0%, var(--EZ) 48%, #55792e 52%, var(--EZ) 100%);
+    background: linear-gradient(180deg, var(--EZ) 0%, var(--EZ) 48%, var(--phi-theme-EZ-dark, #55792e) 52%, var(--EZ) 100%);
 }
 
 .HD {
-    background: linear-gradient(180deg, var(--HD) 0%, var(--HD) 48%, #005c7d 52%, var(--HD) 100%);
+    background: linear-gradient(180deg, var(--HD) 0%, var(--HD) 48%, var(--phi-theme-HD-dark, #005c7d) 52%, var(--HD) 100%);
 }
 
 .IN {
-    background: linear-gradient(180deg, var(--IN) 0%, var(--IN) 48%, #7b0000 52%, var(--IN) 100%);
+    background: linear-gradient(180deg, var(--IN) 0%, var(--IN) 48%, var(--phi-theme-IN-dark, #7b0000) 52%, var(--IN) 100%);
 }
 
 .AT {
-    background: linear-gradient(180deg, var(--AT) 0%, var(--AT) 48%, #292929 52%, var(--AT) 100%);
+    background: linear-gradient(180deg, var(--AT) 0%, var(--AT) 48%, var(--phi-theme-AT-dark, #292929) 52%, var(--AT) 100%);
 }
 
 .EZ-box {

--- a/resources/html/b19/b19.art
+++ b/resources/html/b19/b19.art
@@ -1,7 +1,7 @@
 {{extend defaultLayout}}
 
 {{block 'css'}}
-{{if themeInfo && themeInfo.cssUrl}}
+{{if themeInfo && themeInfo.cssUrl && themeInfo.cssMode == "replace"}}
 <link rel="stylesheet" href="{{themeInfo.cssUrl}}">
 {{else}}
 <link rel="stylesheet" href="{{_res_path}}html/b19/b19.css">
@@ -122,7 +122,7 @@
             </div>
             <div class="songinfo">
                 <div class="Rating">
-                    <img src="{{themeInfo && themeInfo.icons[song.Rating] ? themeInfo.icons[song.Rating] : (_res_path + 'html/otherimg/' + song.Rating + '.png')}}" alt="{{song.Rating}}">
+                    <img src="{{themeInfo && themeInfo.icons && themeInfo.icons[song.Rating] ? themeInfo.icons[song.Rating] : (_res_path + 'html/otherimg/' + song.Rating + '.png')}}" alt="{{song.Rating}}">
                 </div>
                 <div class="chengji">
                     <div class="score">
@@ -256,7 +256,7 @@
             </div>
             <div class="songinfo">
                 <div class="Rating">
-                    <img src="{{themeInfo && themeInfo.icons[song.Rating] ? themeInfo.icons[song.Rating] : (_res_path + 'html/otherimg/' + song.Rating + '.png')}}" alt="{{song.Rating}}">
+                    <img src="{{themeInfo && themeInfo.icons && themeInfo.icons[song.Rating] ? themeInfo.icons[song.Rating] : (_res_path + 'html/otherimg/' + song.Rating + '.png')}}" alt="{{song.Rating}}">
                 </div>
                 <div class="chengji">
                     <div class="score">

--- a/resources/html/b19/b19.css
+++ b/resources/html/b19/b19.css
@@ -356,19 +356,19 @@ body p {
 }
 
 .rank-AT {
-  background-color: rgb(110, 110, 110);
+  background-color: var(--phi-theme-AT, rgb(110, 110, 110));
 }
 
 .rank-IN {
-  background-color: rgb(255, 0, 0);
+  background-color: var(--phi-theme-IN, rgb(255, 0, 0));
 }
 
 .rank-HD {
-  background-color: #00b0f0;
+  background-color: var(--phi-theme-HD, #00b0f0);
 }
 
 .rank-EZ {
-  background-color: #92d050;
+  background-color: var(--phi-theme-EZ, #92d050);
 }
 
 .org,

--- a/resources/html/b19/themes/README.md
+++ b/resources/html/b19/themes/README.md
@@ -1,0 +1,23 @@
+# 自定义主题包
+
+每个主题放在本目录下的独立文件夹中，并通过 `info.yaml` 声明资源。`css` 推荐使用页面映射：
+
+```yaml
+font: "font.ttf"
+background: "background.png"
+color:
+  AT: "#555555"
+  IN: "#7b5ea7"
+  HD: "#5b9bd5"
+  EZ: "#7ecb8a"
+css:
+  b19: "b19.css"
+  sign: "sign.css"
+  setting/userSetting: "user-setting.css"
+```
+
+短键（如 `setting`）作用于该目录下的所有模板；完整键（如 `setting/userSetting`）优先级更高，只作用于指定模板。可用键取自渲染路径，目前常用短键包括 `b19`、`sign`、`update`、`clg`、`arcgrosB19`、`suggest`、`table`、`list`、`historyB30`、`setting`、`difficultyHistory` 和 `help`。
+
+页面始终先加载插件自带 CSS，再加载映射到该页面的主题 CSS。只有页面命中有效 CSS 文件时才会启用主题字体；未命中时保留插件默认 CSS 和字体，但仍会继承主题包声明的背景与难度颜色。
+
+旧版 `css: "b19.css"` 仍受支持，并保持原有语义：仅作用于 `b19/b19`，且替换而不是叠加插件自带的 B19 CSS。

--- a/resources/html/b19/themes/milthm/arcgrosB19.css
+++ b/resources/html/b19/themes/milthm/arcgrosB19.css
@@ -15,6 +15,10 @@
   line-height: 1;
 }
 
+.player_broad img {
+  top: -95%;
+}
+
 .arcChallenge {
   bottom: 2px;
   width: 100%;

--- a/resources/html/b19/themes/milthm/arcgrosB19.css
+++ b/resources/html/b19/themes/milthm/arcgrosB19.css
@@ -1,0 +1,32 @@
+:root {
+  --milthm-panel: rgba(16, 16, 24, 0.72);
+  --milthm-border: rgba(184, 218, 236, 0.3);
+  --milthm-radius: 14px;
+}
+
+.player_idBox,
+.date,
+.song_box {
+  filter: drop-shadow(0 0 4px color-mix(in srgb, var(--HD) 40%, transparent));
+}
+
+.rks_num p,
+.rks_num p span {
+  line-height: 1;
+}
+
+.arcChallenge {
+  bottom: 2px;
+  width: 100%;
+  height: 14px;
+}
+
+.arcChallenge p {
+  margin: 0;
+  line-height: 14px;
+}
+
+.song_info,
+.suggest_box {
+  border-radius: var(--milthm-radius);
+}

--- a/resources/html/b19/themes/milthm/b19.art
+++ b/resources/html/b19/themes/milthm/b19.art
@@ -1,7 +1,7 @@
 {{extend defaultLayout}}
 
 {{block 'css'}}
-<link rel="stylesheet" href="{{themeInfo.cssUrl}}">
+<link rel="stylesheet" href="{{_res_path}}html/b19/b19.css">
 {{/block}}
 
 {{block 'main'}}
@@ -117,7 +117,7 @@
             </div>
             <div class="songinfo">
                 <div class="Rating">
-                    <img src="{{themeInfo.icons[song.Rating] || (_res_path + 'html/otherimg/' + song.Rating + '.png')}}" alt="{{song.Rating}}">
+                    <img src="{{themeInfo && themeInfo.icons && themeInfo.icons[song.Rating] ? themeInfo.icons[song.Rating] : (_res_path + 'html/otherimg/' + song.Rating + '.png')}}" alt="{{song.Rating}}">
                 </div>
                 <div class="chengji">
                     <div class="score">
@@ -251,7 +251,7 @@
             </div>
             <div class="songinfo">
                 <div class="Rating">
-                    <img src="{{themeInfo.icons[song.Rating] || (_res_path + 'html/otherimg/' + song.Rating + '.png')}}" alt="{{song.Rating}}">
+                    <img src="{{themeInfo && themeInfo.icons && themeInfo.icons[song.Rating] ? themeInfo.icons[song.Rating] : (_res_path + 'html/otherimg/' + song.Rating + '.png')}}" alt="{{song.Rating}}">
                 </div>
                 <div class="chengji">
                     <div class="score">

--- a/resources/html/b19/themes/milthm/b19.css
+++ b/resources/html/b19/themes/milthm/b19.css
@@ -1,5 +1,3 @@
-@import "../../../common/common.css";
-
 body {
   /* writing-mode: vertical-lr; */
   flex-direction: column;
@@ -27,8 +25,8 @@ body p {
   --clipSlope: 0;         /* 关闭全局斜切斜率 */
   --radius: 14px;         /* 主圆角 */
   --radius-sm: 8px;       /* 小元素圆角 */
-  --m-purple: #7b5ea7;    /* milthm 主题强调色（与 info.yaml IN 一致） */
-  --m-blue: #5b9bd5;      /* 次级强调色（与 info.yaml HD 一致） */
+  --m-purple: var(--phi-theme-IN, #7b5ea7);
+  --m-blue: var(--phi-theme-HD, #5b9bd5);
   --panel: rgba(16, 16, 24, 0.55);   /* 半透明面板底 */
 }
 
@@ -134,9 +132,27 @@ body p {
 
 .clgBox p {
   font-size: 1.5rem;
-  margin-top: 7px;
   color: white;
-  margin-left: 3px;
+  margin: 0;
+  line-height: 1;
+}
+
+.clgBox .Challenge {
+  position: relative;
+  display: grid;
+  width: 100%;
+  height: 100%;
+  place-items: center;
+}
+
+.clgBox .Challenge > * {
+  grid-area: 1 / 1;
+}
+
+.clgBox .Challenge img {
+  width: 100%;
+  height: auto;
+  margin: 0;
 }
 
 .date {
@@ -323,7 +339,7 @@ body p {
 .phi_song .info-IN,
 .phi_song .info-HD,
 .phi_song .info-EZ {
-  filter: drop-shadow(0 0 10px rgba(123, 94, 167, 0.75));
+  filter: drop-shadow(0 0 10px color-mix(in srgb, var(--m-purple) 75%, transparent));
 }
 
 .b_song .info-AT,
@@ -605,7 +621,7 @@ body p {
 }
 
 .accHyper {
-  --bkgColor: rgba(91, 155, 213, 0.3);
+  --bkgColor: color-mix(in srgb, var(--m-blue) 30%, transparent);
   --lineColor: var(--m-blue);
 }
 
@@ -892,7 +908,7 @@ body p {
   background: rgba(0, 0, 0, 0.62);
   border: 1px solid rgba(255, 255, 255, 0.14);
   border-top: 2px solid rgba(255, 255, 255, 0.9);
-  border-bottom: 2px solid rgba(123, 94, 167, 0.75);
+  border-bottom: 2px solid color-mix(in srgb, var(--m-purple) 75%, transparent);
   backdrop-filter: blur(7px);
   border-radius: var(--radius);
 }
@@ -1015,7 +1031,7 @@ body p {
 }
 
 .tag-radar-shape {
-  fill: rgba(123, 94, 167, 0.3);
+  fill: color-mix(in srgb, var(--m-purple) 30%, transparent);
   stroke: var(--m-purple);
   stroke-width: 1.8;
 }
@@ -1186,11 +1202,11 @@ body p {
 .histogram-bar {
   width: 72%;
   min-height: 2px;
-  box-shadow: 0 0 10px rgba(123, 94, 167, 0.25);
+  box-shadow: 0 0 10px color-mix(in srgb, var(--m-purple) 25%, transparent);
 }
 
 .best-bar {
-  background: linear-gradient(90deg, #7b5ea7, #5b9bd5);
+  background: linear-gradient(90deg, var(--m-purple), var(--m-blue));
 }
 
 .phi-bar {
@@ -1284,10 +1300,10 @@ body p {
 
 .phi-plugin p {
   font-size: xx-large;
-  text-shadow: 0 0 20px rgba(123, 94, 167, 0.8);
+  text-shadow: 0 0 20px color-mix(in srgb, var(--m-purple) 80%, transparent);
 }
 
 .ver p {
   font-size: large;
-  text-shadow: 0 0 20px rgba(91, 155, 213, 0.8);
+  text-shadow: 0 0 20px color-mix(in srgb, var(--m-blue) 80%, transparent);
 }

--- a/resources/html/b19/themes/milthm/b19.css
+++ b/resources/html/b19/themes/milthm/b19.css
@@ -155,6 +155,11 @@ body p {
   margin: 0;
 }
 
+.clgBox .Challenge p {
+  z-index: 1;
+  transform: translateY(-0.3em);
+}
+
 .date {
   position: absolute;
   right: -6px;

--- a/resources/html/b19/themes/milthm/clg.css
+++ b/resources/html/b19/themes/milthm/clg.css
@@ -16,7 +16,7 @@
   clip-path: none;
 }
 
-.dif {
+.dif p {
   color: color-mix(in srgb, var(--HD) 72%, white);
 }
 

--- a/resources/html/b19/themes/milthm/clg.css
+++ b/resources/html/b19/themes/milthm/clg.css
@@ -1,0 +1,37 @@
+:root {
+  --milthm-panel: rgba(16, 16, 24, 0.76);
+  --milthm-border: rgba(184, 218, 236, 0.3);
+  --milthm-radius: 14px;
+}
+
+.song-box {
+  background-color: var(--milthm-panel);
+  border: 1px solid var(--milthm-border);
+  border-radius: var(--milthm-radius);
+  clip-path: none;
+}
+
+.ill-box {
+  border-radius: var(--milthm-radius) 0 0 var(--milthm-radius);
+  clip-path: none;
+}
+
+.dif {
+  color: color-mix(in srgb, var(--HD) 72%, white);
+}
+
+.notes-info {
+  border-color: var(--milthm-border);
+}
+
+.tot-box {
+  background: var(--milthm-panel);
+  border: 1px solid var(--milthm-border);
+  border-radius: var(--milthm-radius);
+  clip-path: none;
+}
+
+.tot_clg p {
+  line-height: 1;
+  text-shadow: 0 0 3px black, 0 0 12px color-mix(in srgb, var(--IN) 58%, white);
+}

--- a/resources/html/b19/themes/milthm/difficultyHistory.css
+++ b/resources/html/b19/themes/milthm/difficultyHistory.css
@@ -1,0 +1,42 @@
+:root {
+  --milthm-panel: rgba(16, 16, 24, 0.72);
+  --milthm-radius: 14px;
+}
+
+.ill-box,
+.title-content,
+.dif-box,
+.a-num {
+  border-radius: var(--milthm-radius);
+  overflow: hidden;
+}
+
+.title-content,
+.ver-box {
+  background: var(--milthm-panel);
+}
+
+.AT-box {
+  --bg-color: linear-gradient(90deg, color-mix(in srgb, var(--AT) 72%, transparent), transparent);
+}
+
+.IN-box {
+  --bg-color: linear-gradient(90deg, color-mix(in srgb, var(--IN) 72%, transparent), transparent);
+}
+
+.HD-box {
+  --bg-color: linear-gradient(90deg, color-mix(in srgb, var(--HD) 72%, transparent), transparent);
+}
+
+.EZ-box {
+  --bg-color: linear-gradient(90deg, color-mix(in srgb, var(--EZ) 72%, transparent), transparent);
+}
+
+.title p,
+.content p,
+.dif-box p,
+.num-box p,
+.update-ver p,
+.update-date p {
+  line-height: 1;
+}

--- a/resources/html/b19/themes/milthm/help.css
+++ b/resources/html/b19/themes/milthm/help.css
@@ -6,6 +6,7 @@
 }
 
 .line {
+  box-sizing: border-box;
   background-color: var(--milthm-panel);
   border: 1px solid var(--milthm-border);
   border-radius: var(--milthm-radius);

--- a/resources/html/b19/themes/milthm/help.css
+++ b/resources/html/b19/themes/milthm/help.css
@@ -1,0 +1,35 @@
+:root {
+  --milthm-panel: rgba(16, 16, 24, 0.72);
+  --milthm-panel-soft: color-mix(in srgb, var(--HD) 24%, transparent);
+  --milthm-border: rgba(184, 218, 236, 0.28);
+  --milthm-radius: 14px;
+}
+
+.line {
+  background-color: var(--milthm-panel);
+  border: 1px solid var(--milthm-border);
+  border-radius: var(--milthm-radius);
+  overflow: hidden;
+}
+
+.order,
+.song,
+.right {
+  background: var(--milthm-panel-soft);
+}
+
+.order {
+  border-color: var(--milthm-border);
+}
+
+.order p,
+.up p,
+.desc p,
+.box-title,
+.box-value {
+  line-height: 1;
+}
+
+.Master {
+  background: color-mix(in srgb, var(--IN) 72%, transparent);
+}

--- a/resources/html/b19/themes/milthm/historyB30.css
+++ b/resources/html/b19/themes/milthm/historyB30.css
@@ -36,7 +36,7 @@
 }
 
 .row {
-  --row-color: var(--HD);
+  --row-color: var(--HD) !important;
 }
 
 .changeTag {

--- a/resources/html/b19/themes/milthm/historyB30.css
+++ b/resources/html/b19/themes/milthm/historyB30.css
@@ -30,6 +30,10 @@
   line-height: 1;
 }
 
+.playerInfo .clgBox .Challenge p {
+  transform: translateY(-0.3em);
+}
+
 .ill,
 .changeTag {
   border-radius: var(--milthm-radius);

--- a/resources/html/b19/themes/milthm/historyB30.css
+++ b/resources/html/b19/themes/milthm/historyB30.css
@@ -1,0 +1,44 @@
+:root {
+  --milthm-border: rgba(184, 218, 236, 0.28);
+  --milthm-radius: 14px;
+}
+
+.playerInfo .clgBox .Challenge {
+  position: relative;
+  display: grid;
+  width: 100%;
+  height: 100%;
+  place-items: center;
+}
+
+.playerInfo .clgBox .Challenge > * {
+  grid-area: 1 / 1;
+}
+
+.playerInfo .clgBox .Challenge img {
+  width: 100%;
+  height: auto;
+  margin: 0;
+}
+
+.playerInfo .clgBox .Challenge p,
+.row-date p,
+.levelKind p,
+.changeTag p {
+  margin-top: 0;
+  margin-bottom: 0;
+  line-height: 1;
+}
+
+.ill,
+.changeTag {
+  border-radius: var(--milthm-radius);
+}
+
+.row {
+  --row-color: var(--HD);
+}
+
+.changeTag {
+  border: 1px solid var(--milthm-border);
+}

--- a/resources/html/b19/themes/milthm/info.yaml
+++ b/resources/html/b19/themes/milthm/info.yaml
@@ -26,6 +26,20 @@ color:
   IN: "#7b5ea7"
   HD: "#5b9bd5"
   EZ: "#7ecb8a"
-# 自定义模板文件，放在主题包目录。
+# 自定义模板文件，仅作用于 B19。
 template: "b19.art"
-css: "b19.css"
+# 按渲染页面加载覆盖样式；可使用 app 或 app/template，完整键优先。
+# 未配置的页面保留插件默认 CSS 和字体，但仍会使用上方配置的背景与难度颜色。
+css:
+  b19: "b19.css"
+  sign: "sign.css"
+  update: "update.css"
+  clg: "clg.css"
+  arcgrosB19: "arcgrosB19.css"
+  suggest: "suggest.css"
+  table: "table.css"
+  list: "list.css"
+  historyB30: "historyB30.css"
+  setting: "setting.css"
+  difficultyHistory: "difficultyHistory.css"
+  help: "help.css"

--- a/resources/html/b19/themes/milthm/list.css
+++ b/resources/html/b19/themes/milthm/list.css
@@ -1,0 +1,38 @@
+:root {
+  --milthm-panel: rgba(16, 16, 24, 0.72);
+  --milthm-border: rgba(184, 218, 236, 0.28);
+  --milthm-radius: 14px;
+}
+
+.line {
+  background-color: var(--milthm-panel);
+  border: 1px solid var(--milthm-border);
+  border-radius: var(--milthm-radius);
+}
+
+.song_name p,
+.song_name span,
+.num p,
+.num span,
+.song p,
+.song span,
+.dif p,
+.dif span {
+  line-height: 1;
+}
+
+.AT {
+  background: color-mix(in srgb, var(--AT) 55%, transparent);
+}
+
+.IN {
+  background: color-mix(in srgb, var(--IN) 55%, transparent);
+}
+
+.HD {
+  background: color-mix(in srgb, var(--HD) 55%, transparent);
+}
+
+.EZ {
+  background: color-mix(in srgb, var(--EZ) 55%, transparent);
+}

--- a/resources/html/b19/themes/milthm/list.css
+++ b/resources/html/b19/themes/milthm/list.css
@@ -5,9 +5,10 @@
 }
 
 .line {
+  box-sizing: border-box;
   background-color: var(--milthm-panel);
   border: 1px solid var(--milthm-border);
-  border-radius: var(--milthm-radius);
+  border-radius: 4px;
 }
 
 .song_name p,

--- a/resources/html/b19/themes/milthm/setting.css
+++ b/resources/html/b19/themes/milthm/setting.css
@@ -1,0 +1,37 @@
+:root {
+  --milthm-panel: rgba(16, 16, 24, 0.74);
+  --milthm-border: rgba(184, 218, 236, 0.28);
+  --milthm-radius: 14px;
+}
+
+.lineBox {
+  border: 1px solid var(--milthm-border);
+  border-radius: var(--milthm-radius);
+  clip-path: none;
+  overflow: hidden;
+}
+
+.line {
+  background: var(--milthm-panel);
+}
+
+.title p,
+.info p,
+.space p,
+.drc p {
+  line-height: 1;
+}
+
+.right {
+  width: 130px;
+}
+
+.space {
+  width: 80px;
+  border-radius: 12px;
+  clip-path: none;
+}
+
+.square {
+  background: var(--HD);
+}

--- a/resources/html/b19/themes/milthm/sign.css
+++ b/resources/html/b19/themes/milthm/sign.css
@@ -62,6 +62,7 @@ body {
   z-index: 1;
   margin: 0;
   line-height: 1;
+  transform: translateY(-0.3em);
 }
 
 .songCover,

--- a/resources/html/b19/themes/milthm/sign.css
+++ b/resources/html/b19/themes/milthm/sign.css
@@ -1,0 +1,80 @@
+:root {
+  --milthm-panel: rgba(16, 16, 24, 0.68);
+  --milthm-panel-strong: rgba(12, 12, 18, 0.82);
+  --milthm-border: rgba(184, 218, 236, 0.28);
+  --milthm-radius: 14px;
+  --milthm-radius-sm: 8px;
+}
+
+body {
+  --bkg-color: var(--milthm-panel);
+}
+
+.backGlass {
+  border-color: var(--milthm-border);
+  border-radius: var(--milthm-radius);
+}
+
+.playerInfo .blackBlock,
+.playerInfo .dataBox,
+.playerInfo .spInfo,
+.luckCard,
+.quoteCard,
+.wordsBox,
+.dailySongsPanel,
+.noticePanel,
+.panelHeader,
+.songItem,
+.noticePanel .noticeBody .calendarWeekHeader,
+.noticePanel .noticeBody .noticeRow.clip-box {
+  border-radius: var(--milthm-radius);
+}
+
+.panelHeader {
+  background: color-mix(in srgb, var(--HD) 68%, transparent);
+}
+
+.songItem,
+.noticePanel,
+.dailySongsPanel {
+  border: 1px solid var(--milthm-border);
+}
+
+.playerInfo .clgBox .Challenge {
+  position: relative;
+  display: grid;
+  width: 100%;
+  height: 100%;
+  place-items: center;
+}
+
+.playerInfo .clgBox .Challenge > * {
+  grid-area: 1 / 1;
+}
+
+.playerInfo .clgBox .Challenge img {
+  width: 100%;
+  height: auto;
+  margin: 0;
+}
+
+.playerInfo .clgBox .Challenge p {
+  z-index: 1;
+  margin: 0;
+  line-height: 1;
+}
+
+.songCover,
+.taskStatus,
+.noticePanel .noticeBody .calendarCell {
+  border-radius: var(--milthm-radius-sm);
+}
+
+.noticePanel .noticeBody .calendarCell.signed {
+  background: color-mix(in srgb, var(--EZ) 28%, transparent);
+  border-color: color-mix(in srgb, var(--EZ) 55%, transparent);
+}
+
+.noticePanel .noticeBody .calendarCell.today {
+  outline-color: color-mix(in srgb, var(--IN) 70%, white);
+}

--- a/resources/html/b19/themes/milthm/suggest.css
+++ b/resources/html/b19/themes/milthm/suggest.css
@@ -1,0 +1,40 @@
+:root {
+  --milthm-panel: rgba(16, 16, 24, 0.72);
+  --milthm-border: rgba(184, 218, 236, 0.28);
+  --milthm-radius: 14px;
+}
+
+.group_title,
+.line {
+  background-color: var(--milthm-panel);
+  border-color: var(--milthm-border);
+  border-radius: var(--milthm-radius);
+}
+
+.group_title p,
+.song_name p,
+.song_name span,
+.num p,
+.num span,
+.song p,
+.song span,
+.dif p,
+.dif span {
+  line-height: 1;
+}
+
+.AT {
+  background: color-mix(in srgb, var(--AT) 55%, transparent);
+}
+
+.IN {
+  background: color-mix(in srgb, var(--IN) 55%, transparent);
+}
+
+.HD {
+  background: color-mix(in srgb, var(--HD) 55%, transparent);
+}
+
+.EZ {
+  background: color-mix(in srgb, var(--EZ) 55%, transparent);
+}

--- a/resources/html/b19/themes/milthm/table.css
+++ b/resources/html/b19/themes/milthm/table.css
@@ -41,7 +41,13 @@
 .queryDifficulty .index p,
 .queryDifficulty .query p,
 .queryDifficulty .total p,
+.phigrosTitle p,
+.titleDesc p,
 .labelContent p,
 .rank p {
   line-height: 1;
+}
+
+.titleDesc p {
+  white-space: nowrap;
 }

--- a/resources/html/b19/themes/milthm/table.css
+++ b/resources/html/b19/themes/milthm/table.css
@@ -26,6 +26,7 @@
   z-index: 1;
   margin: 0;
   line-height: 1;
+  transform: translateY(-0.3em);
 }
 
 .table-IN {

--- a/resources/html/b19/themes/milthm/table.css
+++ b/resources/html/b19/themes/milthm/table.css
@@ -1,0 +1,47 @@
+:root {
+  --milthm-panel: rgba(16, 16, 24, 0.7);
+  --milthm-border: rgba(184, 218, 236, 0.28);
+  --milthm-radius: 14px;
+}
+
+.playerInfo .clgBox .Challenge {
+  position: relative;
+  display: grid;
+  width: 100%;
+  height: 100%;
+  place-items: center;
+}
+
+.playerInfo .clgBox .Challenge > * {
+  grid-area: 1 / 1;
+}
+
+.playerInfo .clgBox .Challenge img {
+  width: 100%;
+  height: auto;
+  margin: 0;
+}
+
+.playerInfo .clgBox .Challenge p {
+  z-index: 1;
+  margin: 0;
+  line-height: 1;
+}
+
+.table-IN {
+  --IN: var(--phi-theme-IN, #7b5ea7);
+}
+
+.labelContent,
+.song,
+.queryDifficulty .index {
+  border-radius: var(--milthm-radius);
+}
+
+.queryDifficulty .index p,
+.queryDifficulty .query p,
+.queryDifficulty .total p,
+.labelContent p,
+.rank p {
+  line-height: 1;
+}

--- a/resources/html/b19/themes/milthm/update.css
+++ b/resources/html/b19/themes/milthm/update.css
@@ -51,6 +51,7 @@
   z-index: 1;
   margin: 0;
   line-height: 1;
+  transform: translateY(-0.3em);
 }
 
 .coinbox,

--- a/resources/html/b19/themes/milthm/update.css
+++ b/resources/html/b19/themes/milthm/update.css
@@ -1,0 +1,67 @@
+:root {
+  --milthm-panel: rgba(16, 16, 24, 0.7);
+  --milthm-border: rgba(184, 218, 236, 0.26);
+  --milthm-radius: 14px;
+  --milthm-radius-sm: 8px;
+}
+
+.title .r,
+.svg-box,
+.abox {
+  border: 1px solid var(--milthm-border);
+  border-radius: var(--milthm-radius);
+}
+
+.title .r,
+.svg-box {
+  background-color: var(--milthm-panel);
+}
+
+.imgbox,
+.namebox,
+.namebox_ed,
+.namebox_un,
+.songsinfo,
+.songsinfo_ed,
+.songsinfo_un {
+  border-radius: var(--milthm-radius-sm);
+}
+
+.title .r .Challenge-r,
+.title .r .Challenge-r_1 {
+  position: relative;
+  display: grid;
+  place-items: center;
+}
+
+.title .r .Challenge-r > *,
+.title .r .Challenge-r_1 > * {
+  grid-area: 1 / 1;
+}
+
+.title .r .Challenge-r img,
+.title .r .Challenge-r_1 img {
+  width: 100%;
+  height: auto;
+  margin: 0;
+}
+
+.title .r .Challenge-r p,
+.title .r .Challenge-r_1 p {
+  z-index: 1;
+  margin: 0;
+  line-height: 1;
+}
+
+.coinbox,
+.coinbox_un {
+  border-radius: var(--milthm-radius-sm);
+}
+
+.coinbox {
+  background: color-mix(in srgb, var(--EZ) 72%, transparent);
+}
+
+.coinbox_un {
+  background: color-mix(in srgb, var(--IN) 72%, transparent);
+}

--- a/resources/html/common/layout/default.art
+++ b/resources/html/common/layout/default.art
@@ -16,17 +16,29 @@
     {{block 'css'}}
     {{/block}}
 
+    {{if themeInfo && themeInfo.cssUrl && themeInfo.cssMode == "overlay"}}
+    <link rel="stylesheet" href="{{themeInfo.cssUrl}}">
+    {{/if}}
+
     {{if themeInfo}}
-    <!-- 主题样式置于 css 之后：主题 css 可能 @import common.css，若提前注入会被 common.css 的同优先级 :root/body 规则覆盖 -->
+    <!-- 清单中的颜色和字体置于页面/主题 CSS 之后，保证清单配置优先。 -->
     <style>
         {{if themeInfo.fontUrl}}
         @font-face { font-family: "phi-theme"; src: url("{{themeInfo.fontUrl}}") format("truetype"); }
         {{/if}}
         {{if themeInfo.colors}}
-        :root { --AT: {{themeInfo.colors.AT}}; --IN: {{themeInfo.colors.IN}}; --HD: {{themeInfo.colors.HD}}; --EZ: {{themeInfo.colors.EZ}}; }
+        :root {
+            {{if themeInfo.colors.AT}}--AT: {{themeInfo.colors.AT}}; --phi-theme-AT: {{themeInfo.colors.AT}}; --phi-theme-AT-dark: color-mix(in srgb, {{themeInfo.colors.AT}} 50%, black);{{/if}}
+            {{if themeInfo.colors.IN}}--IN: {{themeInfo.colors.IN}}; --phi-theme-IN: {{themeInfo.colors.IN}}; --phi-theme-IN-dark: color-mix(in srgb, {{themeInfo.colors.IN}} 50%, black);{{/if}}
+            {{if themeInfo.colors.HD}}--HD: {{themeInfo.colors.HD}}; --phi-theme-HD: {{themeInfo.colors.HD}}; --phi-theme-HD-dark: color-mix(in srgb, {{themeInfo.colors.HD}} 50%, black);{{/if}}
+            {{if themeInfo.colors.EZ}}--EZ: {{themeInfo.colors.EZ}}; --phi-theme-EZ: {{themeInfo.colors.EZ}}; --phi-theme-EZ-dark: color-mix(in srgb, {{themeInfo.colors.EZ}} 50%, black);{{/if}}
+        }
         {{/if}}
         {{if themeInfo.fontUrl}}
         body { font-family: "phi-theme", "PHI", "NOTO", "NotoSansJP", "HIMALAYA", "NotoSansMath-Regular"; }
+        {{/if}}
+        {{if themeInfo.backgroundUrl}}
+        body > .background:not(.theme-background) { display: none; }
         {{/if}}
     </style>
     {{/if}}
@@ -36,7 +48,7 @@
 <body class="elem-{{element || elem || `hydro`}} {{displayMode || mode || `default`}}-mode  {{bodyClass}}" {{@sys.scale}}>
 
 
-    <div class="background">
+    <div class="background theme-background">
         {{if themeInfo && themeInfo.backgroundUrl}}
         <img src="{{themeInfo.backgroundUrl}}" alt="主题背景"
             style="object-fit: cover; min-width: 100%;">

--- a/resources/html/difficultyHistory/difficultyHistory.css
+++ b/resources/html/difficultyHistory/difficultyHistory.css
@@ -92,19 +92,27 @@ body {
 }
 
 .AT-box {
-  --bg-color: linear-gradient(90deg, #6e6e6e88 0%, #37373788 100%);
+  --bg-color: linear-gradient(90deg,
+    color-mix(in srgb, var(--phi-theme-AT, #6e6e6e) 53.33%, transparent) 0%,
+    color-mix(in srgb, var(--phi-theme-AT-dark, #373737) 53.33%, transparent) 100%);
 }
 
 .IN-box {
-  --bg-color: linear-gradient(90deg, #ff000088 0%, #7f000088 100%);
+  --bg-color: linear-gradient(90deg,
+    color-mix(in srgb, var(--phi-theme-IN, #ff0000) 53.33%, transparent) 0%,
+    color-mix(in srgb, var(--phi-theme-IN-dark, #7f0000) 53.33%, transparent) 100%);
 }
 
 .HD-box {
-  --bg-color: linear-gradient(90deg, #00b0f088 0%, #00587888 100%);
+  --bg-color: linear-gradient(90deg,
+    color-mix(in srgb, var(--phi-theme-HD, #00b0f0) 53.33%, transparent) 0%,
+    color-mix(in srgb, var(--phi-theme-HD-dark, #005878) 53.33%, transparent) 100%);
 }
 
 .EZ-box {
-  --bg-color: linear-gradient(90deg, #92d05088 0%, #49682888 100%);
+  --bg-color: linear-gradient(90deg,
+    color-mix(in srgb, var(--phi-theme-EZ, #92d050) 53.33%, transparent) 0%,
+    color-mix(in srgb, var(--phi-theme-EZ-dark, #496828) 53.33%, transparent) 100%);
 }
 
 .AT-box,

--- a/resources/html/list/list.css
+++ b/resources/html/list/list.css
@@ -121,19 +121,19 @@ body p {
 }
 
 .AT {
-    background: #9c9c9c88;
+    background: color-mix(in srgb, var(--phi-theme-AT, #9c9c9c) 53.33%, transparent);
 }
 
 .IN {
-    background: #ff616188;
+    background: color-mix(in srgb, var(--phi-theme-IN, #ff6161) 53.33%, transparent);
 }
 
 .HD {
-    background: #009dff88;
+    background: color-mix(in srgb, var(--phi-theme-HD, #009dff) 53.33%, transparent);
 }
 
 .EZ {
-    background: #7ae07a88;
+    background: color-mix(in srgb, var(--phi-theme-EZ, #7ae07a) 53.33%, transparent);
 }
 
 .ill_box {

--- a/resources/html/suggest/suggest.css
+++ b/resources/html/suggest/suggest.css
@@ -133,19 +133,19 @@ body p {
 }
 
 .AT {
-  background: #9c9c9c88;
+  background: color-mix(in srgb, var(--phi-theme-AT, #9c9c9c) 53.33%, transparent);
 }
 
 .IN {
-  background: #ff616188;
+  background: color-mix(in srgb, var(--phi-theme-IN, #ff6161) 53.33%, transparent);
 }
 
 .HD {
-  background: #009dff88;
+  background: color-mix(in srgb, var(--phi-theme-HD, #009dff) 53.33%, transparent);
 }
 
 .EZ {
-  background: #7ae07a88;
+  background: color-mix(in srgb, var(--phi-theme-EZ, #7ae07a) 53.33%, transparent);
 }
 
 .ill_box {

--- a/resources/html/table/table.css
+++ b/resources/html/table/table.css
@@ -295,7 +295,7 @@ body {
 }
 
 .table-IN {
-  --IN: #ff5d5d;
+  --IN: var(--phi-theme-IN, #ff5d5d);
   --shadow-color: var(--IN);
   --bkg-color: var(--IN);
 }

--- a/tests/themeManager.test.js
+++ b/tests/themeManager.test.js
@@ -4,7 +4,7 @@ import path from 'node:path'
 import test from 'node:test'
 import art from 'art-template'
 import themeManager from '../model/themeManager.js'
-import { pluginResources } from '../model/path.js'
+import { pluginResources } from '../model/filesystem/path.js'
 
 const THEMES_DIR = path.join(pluginResources, 'html', 'b19', 'themes')
 const RES = 'resources/'
@@ -47,17 +47,226 @@ test('getThemeOptions 合并内置与自定义，自定义主题序号从 4 开�
 })
 
 test('getRenderInfo：自定义主题返回模板路径与 themeInfo，资源 url 完整', () => {
-    const info = themeManager.getRenderInfo('milthm', RES)
+    const info = themeManager.getRenderInfo('milthm', RES, 'b19')
     assert.ok(info)
     assert.match(info.tplFile ?? '', /themes[\\/]milthm[\\/]b19\.art$/)
     assert.equal(info.themeInfo.id, 'milthm')
     assert.equal(info.themeInfo.baseUrl, 'resources/html/b19/themes/milthm/')
     assert.equal(info.themeInfo.cssUrl, 'resources/html/b19/themes/milthm/b19.css')
+    assert.equal(info.themeInfo.cssMode, 'overlay')
     assert.equal(info.themeInfo.fontUrl, 'resources/html/b19/themes/milthm/font.ttf')
     assert.equal(info.themeInfo.backgroundUrl, 'resources/html/b19/themes/milthm/bg.png')
     assert.equal(info.themeInfo.icons.phi, 'resources/html/b19/themes/milthm/phi.png')
     assert.equal(info.themeInfo.icons.FC, 'resources/html/b19/themes/milthm/FC.png')
     assert.deepEqual(info.themeInfo.colors, { AT: '#555555', IN: '#7b5ea7', HD: '#5b9bd5', EZ: '#7ecb8a' })
+})
+
+test('getRenderInfo：按页面选择 CSS，缺省页面保留背景和颜色但不启用主题字体', () => {
+    const pages = [
+        'b19', 'sign', 'update', 'clg', 'arcgrosB19', 'suggest', 'table',
+        'list', 'historyB30', 'setting', 'difficultyHistory', 'help',
+    ]
+    for (const page of pages) {
+        const info = themeManager.getRenderInfo('milthm', RES, `${page}/${page}`)
+        assert.ok(info)
+        assert.equal(info.themeInfo.cssUrl, `resources/html/b19/themes/milthm/${page}.css`)
+        assert.equal(info.themeInfo.cssMode, 'overlay')
+        assert.equal(info.themeInfo.fontUrl, 'resources/html/b19/themes/milthm/font.ttf')
+    }
+
+    const fallback = themeManager.getRenderInfo('milthm', RES, 'unconfiguredPage')
+    assert.ok(fallback)
+    assert.equal(fallback.themeInfo.cssUrl, undefined)
+    assert.equal(fallback.themeInfo.fontUrl, undefined)
+    assert.equal(fallback.themeInfo.backgroundUrl, 'resources/html/b19/themes/milthm/bg.png')
+    assert.deepEqual(fallback.themeInfo.colors, { AT: '#555555', IN: '#7b5ea7', HD: '#5b9bd5', EZ: '#7ecb8a' })
+})
+
+test('仅配置背景和难度色的主题可用默认 B19 模板与图标渲染', () => {
+    const testId = '__theme_colors_only__'
+    const testDir = path.join(THEMES_DIR, testId)
+    try {
+        fs.mkdirSync(testDir, { recursive: true })
+        fs.writeFileSync(path.join(testDir, 'info.yaml'), [
+            `id: "${testId}"`,
+            'name: "Colors only"',
+            'background: "background.png"',
+            'color:',
+            '  AT: "#111111"',
+            '  IN: "#222222"',
+            '  HD: "#333333"',
+            '  EZ: "#444444"',
+            '',
+        ].join('\n'))
+        fs.writeFileSync(path.join(testDir, 'background.png'), 'fixture')
+        themeManager.scan()
+
+        const info = themeManager.getRenderInfo(testId, RES, 'b19')
+        assert.ok(info)
+        assert.equal(info.themeInfo.cssUrl, undefined)
+        assert.equal(info.themeInfo.fontUrl, undefined)
+        assert.equal(info.themeInfo.icons, undefined)
+
+        const source = fs.readFileSync(path.join(pluginResources, 'html', 'b19', 'b19.art'), 'utf8')
+        const html = art.render(source, renderData(testId, info.themeInfo))
+        assert.ok(html.includes('html/b19/b19.css'))
+        assert.ok(html.includes('html/otherimg/FC.png'))
+        assert.ok(html.includes(info.themeInfo.backgroundUrl))
+        assert.ok(html.includes('--phi-theme-IN: #222222'))
+    } finally {
+        fs.rmSync(testDir, { recursive: true, force: true })
+        themeManager.scan()
+    }
+})
+
+test('新版页面 CSS 优先匹配完整渲染目标，再回退到 app 短键', () => {
+    const testId = '__theme_page_keys__'
+    const testDir = path.join(THEMES_DIR, testId)
+    try {
+        fs.mkdirSync(testDir, { recursive: true })
+        fs.writeFileSync(path.join(testDir, 'info.yaml'), [
+            `id: "${testId}"`,
+            'name: "Page keys"',
+            'font: "font.ttf"',
+            'css:',
+            '  setting: "setting.css"',
+            '  setting/userSetting: "user-setting.css"',
+            '  setting/missing: "missing.css"',
+            '  invalid/path/extra: "ignored.css"',
+            '',
+        ].join('\n'))
+        for (const file of ['font.ttf', 'setting.css', 'user-setting.css']) {
+            fs.writeFileSync(path.join(testDir, file), 'fixture')
+        }
+        themeManager.scan()
+
+        const exact = themeManager.getRenderInfo(testId, RES, 'setting/userSetting')
+        assert.match(exact?.themeInfo.cssUrl ?? '', /\/user-setting\.css$/)
+        assert.match(exact?.themeInfo.fontUrl ?? '', /\/font\.ttf$/)
+
+        const fallback = themeManager.getRenderInfo(testId, RES, 'setting/missing')
+        assert.match(fallback?.themeInfo.cssUrl ?? '', /\/setting\.css$/)
+
+        const short = themeManager.getRenderInfo(testId, RES, 'setting')
+        assert.match(short?.themeInfo.cssUrl ?? '', /\/setting\.css$/)
+        assert.equal(themeManager.getTheme(testId)?.css?.['invalid/path/extra'], undefined)
+    } finally {
+        fs.rmSync(testDir, { recursive: true, force: true })
+        themeManager.scan()
+    }
+})
+
+test('旧版字符串 css 仅替换 B19 样式，其他页面使用默认 CSS 和字体', () => {
+    const testId = '__theme_legacy_css__'
+    const testDir = path.join(THEMES_DIR, testId)
+    try {
+        fs.mkdirSync(testDir, { recursive: true })
+        fs.writeFileSync(path.join(testDir, 'info.yaml'), [
+            `id: "${testId}"`,
+            'name: "Legacy CSS"',
+            'font: "font.ttf"',
+            'background: "background.png"',
+            'css: "b19.css"',
+            'icon:',
+            '  FC: "FC.png"',
+            'color:',
+            '  IN: "#123456"',
+            '',
+        ].join('\n'))
+        for (const file of ['font.ttf', 'background.png', 'b19.css', 'FC.png']) {
+            fs.writeFileSync(path.join(testDir, file), 'fixture')
+        }
+        themeManager.scan()
+
+        const b19 = themeManager.getRenderInfo(testId, RES, 'b19')
+        assert.ok(b19)
+        assert.match(b19.themeInfo.cssUrl, /__theme_legacy_css__\/b19\.css$/)
+        assert.equal(b19.themeInfo.cssMode, 'replace')
+        assert.match(b19.themeInfo.fontUrl, /__theme_legacy_css__\/font\.ttf$/)
+
+        const source = fs.readFileSync(path.join(pluginResources, 'html', 'b19', 'b19.art'), 'utf8')
+        const html = art.render(source, renderData(testId, b19.themeInfo))
+        assert.ok(html.includes(b19.themeInfo.cssUrl))
+        assert.ok(!html.includes('html/b19/b19.css'))
+        assert.equal(html.split(b19.themeInfo.cssUrl).length - 1, 1)
+
+        const sign = themeManager.getRenderInfo(testId, RES, 'sign')
+        assert.ok(sign)
+        assert.equal(sign.themeInfo.cssUrl, undefined)
+        assert.equal(sign.themeInfo.cssMode, undefined)
+        assert.equal(sign.themeInfo.fontUrl, undefined)
+        assert.match(sign.themeInfo.backgroundUrl, /__theme_legacy_css__\/background\.png$/)
+        assert.deepEqual(sign.themeInfo.colors, { IN: '#123456' })
+    } finally {
+        fs.rmSync(testDir, { recursive: true, force: true })
+        themeManager.scan()
+    }
+})
+
+test('主题资源 URL 使用实际目录名，并拒绝越界路径和符号链接', () => {
+    const dirName = '__theme_actual_dir__'
+    const testId = '__theme_different_id__'
+    const testDir = path.join(THEMES_DIR, dirName)
+    const outsideFile = path.join(THEMES_DIR, '__theme_outside.css')
+    let symlinkCreated = false
+    try {
+        fs.mkdirSync(testDir, { recursive: true })
+        fs.writeFileSync(path.join(testDir, 'info.yaml'), [
+            `id: "${testId}"`,
+            'name: "Path safety"',
+            'background: "background.png"',
+            'css:',
+            '  sign: "valid.css"',
+            '  update: "../__theme_outside.css"',
+            '  help: "linked.css"',
+            '',
+        ].join('\n'))
+        fs.writeFileSync(path.join(testDir, 'valid.css'), 'fixture')
+        fs.writeFileSync(path.join(testDir, 'background.png'), 'fixture')
+        fs.writeFileSync(outsideFile, 'fixture')
+        try {
+            fs.symlinkSync(outsideFile, path.join(testDir, 'linked.css'))
+            symlinkCreated = true
+        } catch { }
+        themeManager.scan()
+
+        const sign = themeManager.getRenderInfo(testId, RES, 'sign/sign')
+        assert.equal(sign?.themeInfo.baseUrl, `resources/html/b19/themes/${dirName}/`)
+        assert.equal(sign?.themeInfo.cssUrl, `resources/html/b19/themes/${dirName}/valid.css`)
+        assert.equal(sign?.themeInfo.backgroundUrl, `resources/html/b19/themes/${dirName}/background.png`)
+
+        const escaped = themeManager.getRenderInfo(testId, RES, 'update/update')
+        assert.equal(escaped?.themeInfo.cssUrl, undefined)
+        if (symlinkCreated) {
+            const linked = themeManager.getRenderInfo(testId, RES, 'help/help')
+            assert.equal(linked?.themeInfo.cssUrl, undefined)
+        }
+    } finally {
+        fs.rmSync(testDir, { recursive: true, force: true })
+        fs.rmSync(outsideFile, { force: true })
+        themeManager.scan()
+    }
+})
+
+test('主题根目录符号链接不会被注册', (t) => {
+    const testId = '__theme_linked_root__'
+    const linkedDir = path.join(THEMES_DIR, testId)
+    const externalDir = fs.mkdtempSync(path.join(path.dirname(THEMES_DIR), '__theme_external_root__'))
+    try {
+        fs.writeFileSync(path.join(externalDir, 'info.yaml'), `id: "${testId}"\nname: "Linked root"\n`)
+        try {
+            fs.symlinkSync(externalDir, linkedDir, 'dir')
+        } catch {
+            t.skip('当前环境不支持创建目录符号链接')
+            return
+        }
+        themeManager.scan()
+        assert.ok(!themeManager.isCustomTheme(testId))
+    } finally {
+        fs.rmSync(linkedDir, { force: true })
+        fs.rmSync(externalDir, { recursive: true, force: true })
+        themeManager.scan()
+    }
 })
 
 test('getRenderInfo：dss2 返回内置模板路径且 themeInfo 为 null，default/snow/star 返回 null', () => {
@@ -80,14 +289,16 @@ test('热更新：新增/修改/删除主题目录无需重启即可生效', asy
             `name: "HotReload"\nid: "${testId}"\ndescription: "hot reload test"\n`)
         assert.ok(await waitFor(() => themeManager.isCustomTheme(testId)), '新增主题未被注册')
 
-        const before = themeManager.getThemeOptions()[testId]
+        const beforeOptions = themeManager.getThemeOptions()
+        const before = beforeOptions[testId]
+        const beforeIndex = Object.keys(beforeOptions).indexOf(testId)
         fs.writeFileSync(path.join(testDir, 'info.yaml'),
             `name: "HotReloadV2"\nid: "${testId}"\ndescription: "updated"\n`)
         assert.ok(await waitFor(() => themeManager.getThemeOptions()[testId].description === 'updated'), '修改 info.yaml 未生效')
 
         fs.rmSync(testDir, { recursive: true, force: true })
         assert.ok(await waitFor(() => !themeManager.isCustomTheme(testId)), '删除主题未生效')
-        assert.equal(before.title, '[5]HotReload')
+        assert.equal(before.title, `[${beforeIndex}]HotReload`)
     } finally {
         fs.rmSync(testDir, { recursive: true, force: true })
     }
@@ -165,14 +376,15 @@ test('默认 b19.art：themeInfo 为 null 时保持原样（默认 css 与 other
     assert.ok(!html.includes('themes/milthm'))
 })
 
-test('默认 b19.art 主题感知：有 themeInfo 时切换为主题 css 与图标，缺失图标回退默认', () => {
-    const info = themeManager.getRenderInfo('milthm', RES)
+test('默认 b19.art 主题感知：新版覆盖样式后置，图标缺失时回退默认', () => {
+    const info = themeManager.getRenderInfo('milthm', RES, 'b19')
     assert.ok(info)
     const source = fs.readFileSync(path.join(pluginResources, 'html', 'b19', 'b19.art'), 'utf8')
     const html = art.render(source, renderData('milthm', info.themeInfo))
     assert.ok(html.includes(info.themeInfo.cssUrl))
     assert.ok(html.includes(info.themeInfo.icons.FC))
-    assert.ok(!html.includes('html/b19/b19.css'))
+    assert.ok(html.includes('html/b19/b19.css'))
+    assert.ok(html.indexOf('html/b19/b19.css') < html.indexOf(info.themeInfo.cssUrl))
     // NEW 未提供图标 → 回退默认
     const htmlNew = art.render(source, {
         ...renderData('milthm', info.themeInfo),
@@ -182,10 +394,11 @@ test('默认 b19.art 主题感知：有 themeInfo 时切换为主题 css 与图�
 })
 
 test('milthm b19.art：使用主题 css 与图标，无 snow/star/topText 分支', () => {
-    const info = themeManager.getRenderInfo('milthm', RES)
+    const info = themeManager.getRenderInfo('milthm', RES, 'b19')
     assert.ok(info)
     const source = fs.readFileSync(path.join(info.themeInfo.baseUrl.replace('resources/', pluginResources.replace(/\\/g, '/') + '/'), 'b19.art'), 'utf8')
     const html = art.render(source, renderData('milthm', info.themeInfo))
+    assert.ok(html.includes('html/b19/b19.css'))
     assert.ok(html.includes(info.themeInfo.cssUrl))
     assert.ok(html.includes(info.themeInfo.icons.FC))
     assert.ok(html.includes('phi_song'))
@@ -197,7 +410,7 @@ test('milthm b19.art：使用主题 css 与图标，无 snow/star/topText 分支
 test('default.art 布局：themeInfo 注入字体/难度色/背景，无 themeInfo 时与现状一致', () => {
     const layout = path.join(pluginResources, 'html', 'common', 'layout', 'default.art')
     const source = fs.readFileSync(layout, 'utf8')
-    const info = themeManager.getRenderInfo('milthm', RES)
+    const info = themeManager.getRenderInfo('milthm', RES, 'b19')
     assert.ok(info)
 
     const html = art.render(source, {
@@ -207,11 +420,16 @@ test('default.art 布局：themeInfo 注入字体/难度色/背景，无 themeIn
     assert.ok(html.includes('@font-face'))
     assert.ok(html.includes('font-family: "phi-theme"'))
     assert.ok(html.includes('--AT: #555555'))
+    assert.ok(html.includes('--phi-theme-AT: #555555'))
+    assert.ok(html.includes('--phi-theme-AT-dark: color-mix(in srgb, #555555 50%, black)'))
     assert.ok(html.includes('--IN: #7b5ea7'))
+    assert.ok(html.includes('--phi-theme-IN: #7b5ea7'))
     assert.ok(html.includes('--HD: #5b9bd5'))
     assert.ok(html.includes('--EZ: #7ecb8a'))
     assert.ok(html.includes(info.themeInfo.backgroundUrl))
-    // 主题样式必须位于 css 链接之后：否则会被主题 css @import 的 common.css 同优先级规则覆盖（难度色/字体失效）
+    assert.ok(html.includes('class="background theme-background"'))
+    assert.ok(html.includes('body > .background:not(.theme-background) { display: none; }'))
+    // 清单颜色与字体必须位于主题 CSS 之后，保证清单配置优先。
     assert.ok(html.indexOf(info.themeInfo.cssUrl) < html.indexOf('@font-face'),
         '主题样式应注入在 css 链接之后，以保证覆盖 common.css 默认值')
 
@@ -222,4 +440,60 @@ test('default.art 布局：themeInfo 注入字体/难度色/背景，无 themeIn
     // star 分支不受影响
     const star = art.render(source, { ...renderData('star', null), b19_list: [], phi: [] })
     assert.ok(star.includes('Star1.png'))
+})
+
+test('默认页面 CSS 从主题别名读取难度色', () => {
+    for (const page of ['b19', 'list', 'suggest', 'difficultyHistory', 'arcgrosB19']) {
+        const css = fs.readFileSync(path.join(pluginResources, 'html', page, `${page}.css`), 'utf8')
+        for (const rank of ['AT', 'IN', 'HD', 'EZ']) {
+            assert.ok(css.includes(`--phi-theme-${rank}`), `${page} 未读取 ${rank} 主题色`)
+        }
+    }
+    const table = fs.readFileSync(path.join(pluginResources, 'html', 'table', 'table.css'), 'utf8')
+    assert.ok(table.includes('var(--phi-theme-IN, #ff5d5d)'))
+})
+
+test('sign.art：页面主题样式后置；未配置页面样式时使用默认字体', () => {
+    const source = fs.readFileSync(path.join(pluginResources, 'html', 'sign', 'sign.art'), 'utf8')
+    const signData = {
+        ...renderData('milthm', null),
+        PlayerId: 'TestPlayer',
+        Rks: '15.0000',
+        avatar: 'avatar1',
+        ChallengeMode: '0',
+        ChallengeModeRank: '12',
+        Date: '2026-08-16',
+        Notes: 100,
+        signDays: 5,
+        lucky: 80,
+        good: [],
+        bad: [],
+        quote: 'Test quote',
+        edgeRate: Object.fromEntries(['EZ', 'HD', 'IN', 'AT'].map(rank => [
+            rank,
+            { unlock: '50%', fc: '40%', phi: '30%' },
+        ])),
+        dailyTasks: [],
+        notice: null,
+        calendar: { title: '2026 年 8 月', weekdays: [], weeks: [] },
+    }
+
+    const themed = themeManager.getRenderInfo('milthm', RES, 'sign')
+    assert.ok(themed)
+    const themedHtml = art.render(source, { ...signData, themeInfo: themed.themeInfo })
+    assert.ok(themedHtml.includes('html/sign/sign.css'))
+    assert.ok(themedHtml.includes('themes/milthm/sign.css'))
+    assert.ok(themedHtml.includes('font-family: "phi-theme"'))
+    assert.ok(themedHtml.indexOf('html/sign/sign.css') < themedHtml.indexOf('themes/milthm/sign.css'))
+
+    const fallback = themeManager.getRenderInfo('milthm', RES, 'unconfiguredPage')
+    assert.ok(fallback)
+    const fallbackHtml = art.render(source, { ...signData, themeInfo: fallback.themeInfo })
+    assert.ok(fallbackHtml.includes('html/sign/sign.css'))
+    assert.ok(fallbackHtml.includes(fallback.themeInfo.backgroundUrl))
+    assert.ok(fallbackHtml.includes('--IN: #7b5ea7'))
+    assert.ok(fallbackHtml.includes('--phi-theme-IN: #7b5ea7'))
+    assert.ok(!fallbackHtml.includes('@font-face'))
+    assert.ok(!fallbackHtml.includes('font-family: "phi-theme"'))
+    assert.ok(!fallbackHtml.includes('themes/milthm/sign.css'))
 })

--- a/tests/themeManager.test.js
+++ b/tests/themeManager.test.js
@@ -204,25 +204,26 @@ test('旧版字符串 css 仅替换 B19 样式，其他页面使用默认 CSS �
 })
 
 test('主题资源 URL 使用实际目录名，并拒绝越界路径和符号链接', () => {
-    const dirName = '__theme_actual_dir__'
+    const dirName = '__theme actual#dir%__'
     const testId = '__theme_different_id__'
     const testDir = path.join(THEMES_DIR, dirName)
     const outsideFile = path.join(THEMES_DIR, '__theme_outside.css')
+    const nestedDir = path.join(testDir, 'nested styles')
     let symlinkCreated = false
     try {
-        fs.mkdirSync(testDir, { recursive: true })
+        fs.mkdirSync(nestedDir, { recursive: true })
         fs.writeFileSync(path.join(testDir, 'info.yaml'), [
             `id: "${testId}"`,
             'name: "Path safety"',
-            'background: "background.png"',
+            'background: "background #%.png"',
             'css:',
-            '  sign: "valid.css"',
+            '  sign: "nested styles/valid #%.css"',
             '  update: "../__theme_outside.css"',
             '  help: "linked.css"',
             '',
         ].join('\n'))
-        fs.writeFileSync(path.join(testDir, 'valid.css'), 'fixture')
-        fs.writeFileSync(path.join(testDir, 'background.png'), 'fixture')
+        fs.writeFileSync(path.join(nestedDir, 'valid #%.css'), 'fixture')
+        fs.writeFileSync(path.join(testDir, 'background #%.png'), 'fixture')
         fs.writeFileSync(outsideFile, 'fixture')
         try {
             fs.symlinkSync(outsideFile, path.join(testDir, 'linked.css'))
@@ -231,9 +232,15 @@ test('主题资源 URL 使用实际目录名，并拒绝越界路径和符号链
         themeManager.scan()
 
         const sign = themeManager.getRenderInfo(testId, RES, 'sign/sign')
-        assert.equal(sign?.themeInfo.baseUrl, `resources/html/b19/themes/${dirName}/`)
-        assert.equal(sign?.themeInfo.cssUrl, `resources/html/b19/themes/${dirName}/valid.css`)
-        assert.equal(sign?.themeInfo.backgroundUrl, `resources/html/b19/themes/${dirName}/background.png`)
+        const encodedDir = encodeURIComponent(dirName)
+        assert.equal(sign?.themeInfo.baseUrl, `resources/html/b19/themes/${encodedDir}/`)
+        assert.equal(sign?.themeInfo.cssUrl,
+            `resources/html/b19/themes/${encodedDir}/nested%20styles/valid%20%23%25.css`)
+        assert.equal(sign?.themeInfo.backgroundUrl,
+            `resources/html/b19/themes/${encodedDir}/background%20%23%25.png`)
+        const cssUrl = new URL(sign?.themeInfo.cssUrl ?? '', 'file:///')
+        assert.equal(cssUrl.hash, '')
+        assert.equal(cssUrl.search, '')
 
         const escaped = themeManager.getRenderInfo(testId, RES, 'update/update')
         assert.equal(escaped?.themeInfo.cssUrl, undefined)

--- a/tests/themePageRouting.test.js
+++ b/tests/themePageRouting.test.js
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { phihelp as ApiSettings } from '../apps/apiSetting.js'
+import { phihelp as UserSettings } from '../apps/setting.js'
+import getInfo from '../model/game/getInfo.js'
+import picmodle from '../model/render/picmodle.js'
+import send from '../model/render/send.js'
+import getBanGroup from '../model/user/getBanGroup.js'
+import getNotes from '../model/user/getNotes.js'
+
+/** @param {string} msg */
+const event = msg => ({
+    msg,
+    user_id: 'test-user',
+    self_id: 'test-bot',
+    isGroup: false,
+    isPrivate: true,
+})
+
+const pluginData = () => ({
+    theme: 'milthm',
+    b30AvgKind: 'all',
+    b30AvgColor: 'red',
+    allowApiUsage: true,
+    showB30Analysis: true,
+})
+
+test('用户设置页把当前主题传给完整页面渲染目标', async () => {
+    const originals = {
+        getBan: getBanGroup.get,
+        getNotesData: getNotes.getNotesData,
+        getIll: getInfo.getill,
+        common: picmodle.common,
+        send: send.send_with_At,
+    }
+    /** @type {any[]} */ const renders = []
+
+    getBanGroup.get = async () => false
+    getNotes.getNotesData = async () => /** @type {any} */ (pluginData())
+    getInfo.getill = () => 'background.png'
+    picmodle.common = /** @type {any} */ (async (/** @type {any[]} */ ...args) => {
+        renders.push(args)
+        return 'image'
+    })
+    send.send_with_At = /** @type {any} */ (async () => undefined)
+
+    try {
+        const command = new UserSettings()
+        assert.equal(await command.showUserSetting(/** @type {any} */ (event('/phi myset'))), true)
+        assert.equal(renders.length, 1)
+        assert.equal(renders[0][1], 'setting')
+        assert.equal(renders[0][2].theme, 'milthm')
+        assert.equal(renders[0][3], 'userSetting')
+    } finally {
+        getBanGroup.get = originals.getBan
+        getNotes.getNotesData = originals.getNotesData
+        getInfo.getill = originals.getIll
+        picmodle.common = originals.common
+        send.send_with_At = originals.send
+    }
+})
+
+test('API 用户设置页把当前主题传给完整页面渲染目标', async () => {
+    const originals = {
+        getNotesData: getNotes.getNotesData,
+        getIll: getInfo.getill,
+        common: picmodle.common,
+        send: send.send_with_At,
+    }
+    /** @type {any[]} */ const renders = []
+
+    getNotes.getNotesData = async () => /** @type {any} */ (pluginData())
+    getInfo.getill = () => 'background.png'
+    picmodle.common = /** @type {any} */ (async (/** @type {any[]} */ ...args) => {
+        renders.push(args)
+        return 'image'
+    })
+    send.send_with_At = /** @type {any} */ (async () => undefined)
+
+    try {
+        const command = new ApiSettings()
+        await command.renderApiUserSetting(/** @type {any} */ (event('/phi apiset')), {
+            allowDataCollection: true,
+            allowLeaderboard: true,
+            allowDataAggregation: true,
+            allowPlayerIdSearch: true,
+            allowUserIdSearch: true,
+        })
+        assert.equal(renders.length, 1)
+        assert.equal(renders[0][1], 'setting')
+        assert.equal(renders[0][2].theme, 'milthm')
+        assert.equal(renders[0][3], 'userSetting')
+    } finally {
+        getNotes.getNotesData = originals.getNotesData
+        getInfo.getill = originals.getIll
+        picmodle.common = originals.common
+        send.send_with_At = originals.send
+    }
+})


### PR DESCRIPTION
 ## 背景

  目前多个渲染页面都会传递用户选择的 `theme`。

  旧版自定义主题只能配置 B19 的模板和 CSS，但主题字体、背景等资源会同时影响 `/sign`、`historyB30`、`table` 等其他页面。这导致其他页面加载了自定义字体，却无法在主题包中提供对应 CSS 调整布局。

  当自定义字体的字形尺寸或基线与默认字体不同时，就会出现课题模式数字与底部彩条错位等问题。

  讨论后决定保留“背景随主题切换”的既有逻辑，并让主题包能够为其他页面提供独立 CSS。

  ## 改动内容

  - 支持在主题包 `info.yaml` 中按页面配置 CSS。
  - 支持 `app` 和 `app/template` 两种页面键。
  - 完整页面键优先于 app 短键。
  - 页面配置了主题 CSS 时，加载该 CSS 和主题字体。
  - 页面未配置主题 CSS 时：
    - 使用 phi-plugin 自带 CSS。
    - 使用 phi-plugin 默认字体。
    - 如果主题定义了背景和难度颜色，仍同步应用主题背景与难度颜色。
  - 保持旧版 `css: "b19.css"` 写法兼容，旧格式仍只作用于 B19。
  - 对主题资源路径进行校验，阻止越界路径和符号链接引用。
  - 更新主题开发说明与相关测试。

  ## 配置示例

  ```yaml
  template: "b19.art"

  css:
    b19: "b19.css"
    sign: "sign.css"
    update: "update.css"
    setting/userSetting: "user-setting.css"
```

  页面 CSS 会作为覆盖样式加载在页面原始 CSS 之后。

  ## Milthm 示例主题适配

  为 Milthm 示例主题补充了以下页面的适配：

  - B19
  - Arcgros B19
  - 推分建议
  - 成绩列表
  - 定数表
  - 历史 B30
  - 更新记录
  - 签到页
  - 课题模式
  - 定数历史
  - 设置
  - 帮助

  ## 兼容性

  - 未使用自定义主题时，渲染行为不变。
  - 旧版主题包无需修改即可继续使用。
  - 未配置页面 CSS 的主题不会再把自定义字体应用到该页面。
  - 主题背景和难度颜色仍会按照原有逻辑同步到其他页面。
