### PR TITLE
fix(update): 修正课题模式数字与等级条的相对位置

### DIFF
--- a/resources/html/update/update.css
+++ b/resources/html/update/update.css
@@ -80,7 +80,7 @@ body p {
     margin-right: 0;
     margin-left: 0;
     border-radius: 0px;
-    margin-bottom: -56%;
+    margin-bottom: -65%;
 }
 
 .title .r .Challenge-r p,


### PR DESCRIPTION
## 修改内容

- 将 `/update` 页面课题模式等级条的 `margin-bottom` 从 `-56%` 调整为 `-65%`