### PR TITLE
修复 Arc B30 顶部背景曲绘显示异常

### DIFF
--- a/model/game/fCompute.js
+++ b/model/game/fCompute.js
@@ -90,32 +90,7 @@ export default class fCompute {
      */
     static getBackground(save_background) {
         try {
-            switch (save_background) {
-                case 'Another Me ': {
-                    save_background = 'Another Me (KALPA)'
-                    break
-                }
-                case 'Another Me': {
-                    save_background = 'Another Me (Rising Sun Traxx)'
-                    break
-                }
-                case 'Re_Nascence (Psystyle Ver.) ': {
-                    save_background = 'Re_Nascence (Psystyle Ver.)'
-                    break
-                }
-                case 'Energy Synergy Matrix': {
-                    save_background = 'ENERGY SYNERGY MATRIX'
-                    break
-                }
-                case 'Le temps perdu-': {
-                    save_background = 'Le temps perdu'
-                    break
-                }
-                default: {
-                    break
-                }
-            }
-            return getInfo.getill(/**@type {idString} */(save_background))
+            return getInfo.getBackground(save_background)
         } catch (err) {
             logger.error(`获取背景曲绘错误`, err)
             return false

--- a/tests/backgroundIllustration.test.js
+++ b/tests/backgroundIllustration.test.js
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import fCompute from '../model/game/fCompute.js'
+import getInfo from '../model/game/getInfo.js'
+
+test('个人背景曲绘通过统一解析器获取', () => {
+    const original = getInfo.getBackground
+    const calls = []
+    getInfo.getBackground = background => {
+        calls.push(background)
+        return 'resolved-background.png'
+    }
+
+    try {
+        assert.equal(fCompute.getBackground('Introduction'), 'resolved-background.png')
+        assert.deepEqual(calls, ['Introduction'])
+    } finally {
+        getInfo.getBackground = original
+    }
+})


### PR DESCRIPTION
## 问题来源

曲绘解析逻辑重构后，`getInfo.getill()` 改为接收曲目 ID，同时新增了`getInfo.getBackground()`，负责将存档中的背景曲名规范化并映射为曲目 ID。

Arc B30 使用的 `fCompute.getBackground()` 仍保留旧逻辑，将背景曲名直接传给`getInfo.getill()`。以 `Introduction` 为例，由于曲名无法直接命中 SP 曲目 ID，最终会回退到 `phigros.png`，导致顶部玩家信息横条显示 Phigros 默认图，而不是玩家设置的背景曲绘。

## 修改内容

- 将 `fCompute.getBackground()` 改为调用统一的 `getInfo.getBackground()`。
- 删除两处重复的背景曲名兼容映射，统一由现有解析器维护。
- 恢复普通曲目和 SP 曲目背景的正确解析。
- 新增回归测试，确保 Arc B30 背景通过统一解析器获取。