### PR TITLE
feat(theme): 支持 Info 页面自定义主题

### DIFF
--- a/apps/user.js
+++ b/apps/user.js
@@ -111,6 +111,10 @@ export class phiuser extends phiPluginBase {
             return true
         }
 
+        // /info 使用独立的 userinfo/userinfo 渲染目标，需把当前用户主题传入渲染数据，
+        // 主题管理器才能命中主题包中的完整页面键。
+        const pluginData = await getNotes.getNotesData(e.user_id)
+
         let stats = await save.getStats()
 
         let money = save.gameProgress.money
@@ -261,11 +265,13 @@ export class phiuser extends phiPluginBase {
             acc_rks_range: acc_rks_range,
             acc_rks_AccRange: acc_rks_AccRange_position,
             background: bksong,
+            theme: pluginData?.theme || 'star',
         }
 
         // console.info(acc_rks_AccRange_position)
 
-        let kind = Number(e.msg.replace(/\/.*info/g, ''))
+        const infoVersion = e.msg.match(new RegExp(`^[#/](?:${Config.getUserCfg('config', 'cmdhead')})\\s*info([12])?`, 'i'))?.at(-1)
+        const kind = Number(infoVersion || 0)
         send.send_with_At(e, await picmodle.user_info(e, data, kind))
     }
 

--- a/model/game/getInfo.js
+++ b/model/game/getInfo.js
@@ -98,7 +98,7 @@ export default new class getInfo {
          */
         this.songsid = {}
         /**
-         * @type {{[key:songString]:idString}}
+         * @type {Record<string, idString>}
          * @description 原曲名称获取id
          */
         this.idssong = {}
@@ -257,6 +257,8 @@ export default new class getInfo {
             this.sp_info[id] = { ...sp_json[i] }
             this.sp_info[id].sp_vis = true
             this.sp_info[id].id = id
+            this.idssong[i] = id
+            this.idssong[this.sp_info[id].song] = id
             if (this.sp_info[id]?.illustration) {
                 this.illlist.push(this.sp_info[id].id)
             }
@@ -1008,7 +1010,7 @@ export default new class getInfo {
 
     /**
      * 通过原曲曲目获取曲目id
-     * @param {songString} song 原曲曲名
+     * @param {string} song 原曲曲名
      * @returns {idString | undefined} 曲目id
      */
     SongGetId(song) {

--- a/model/game/getInfo.js
+++ b/model/game/getInfo.js
@@ -98,7 +98,7 @@ export default new class getInfo {
          */
         this.songsid = {}
         /**
-         * @type {Record<string, idString>}
+         * @type {{[key:songString]:idString}}
          * @description 原曲名称获取id
          */
         this.idssong = {}
@@ -257,7 +257,7 @@ export default new class getInfo {
             this.sp_info[id] = { ...sp_json[i] }
             this.sp_info[id].sp_vis = true
             this.sp_info[id].id = id
-            this.idssong[i] = id
+            this.idssong[/** @type {songString} */ (/** @type {unknown} */ (i))] = id
             this.idssong[this.sp_info[id].song] = id
             if (this.sp_info[id]?.illustration) {
                 this.illlist.push(this.sp_info[id].id)
@@ -1010,7 +1010,7 @@ export default new class getInfo {
 
     /**
      * 通过原曲曲目获取曲目id
-     * @param {string} song 原曲曲名
+     * @param {songString} song 原曲曲名
      * @returns {idString | undefined} 曲目id
      */
     SongGetId(song) {

--- a/model/save/Save.js
+++ b/model/save/Save.js
@@ -768,11 +768,13 @@ export default class Save {
         stats[3].title = Level[3]
 
         for (let id of idsFromRecord) {
-            if (!getInfo.info(id)) {
-                continue
-            }
+            // 记录数组会为 Legacy 槽位保留下标 3 的 null 占位，必须以当前曲库谱面为准。
+            const info = getInfo.ori_info[id]
+            if (!info?.chart) continue
             let record = Record[id]
             for (let lv of [0, 1, 2, 3]) {
+                const chart = info.chart[Level[lv]]
+                if (!chart || !Number(chart.difficulty)) continue
                 if (record.length <= lv || record[lv] === undefined) continue
 
                 ++stats[lv].unlock

--- a/resources/html/arcgrosB19/arcgrosB19.css
+++ b/resources/html/arcgrosB19/arcgrosB19.css
@@ -261,7 +261,7 @@ p {
     position: absolute;
     width: 304px;
     height: 20px;
-    right: 5px;
+    right: 40px;
     top: 133px;
 }
 

--- a/resources/html/b19/themes/README.md
+++ b/resources/html/b19/themes/README.md
@@ -14,9 +14,10 @@ css:
   b19: "b19.css"
   sign: "sign.css"
   setting/userSetting: "user-setting.css"
+  userinfo/userinfo: "userinfo.css"
 ```
 
-短键（如 `setting`）作用于该目录下的所有模板；完整键（如 `setting/userSetting`）优先级更高，只作用于指定模板。可用键取自渲染路径，目前常用短键包括 `b19`、`sign`、`update`、`clg`、`arcgrosB19`、`suggest`、`table`、`list`、`historyB30`、`setting`、`difficultyHistory` 和 `help`。
+短键（如 `setting`）作用于该目录下的所有模板；完整键（如 `setting/userSetting` 或 `userinfo/userinfo`）优先级更高，只作用于指定模板。可用键取自渲染路径，目前常用短键包括 `b19`、`sign`、`update`、`clg`、`arcgrosB19`、`suggest`、`table`、`list`、`historyB30`、`setting`、`userinfo`、`difficultyHistory` 和 `help`。
 
 页面始终先加载插件自带 CSS，再加载映射到该页面的主题 CSS。只有页面命中有效 CSS 文件时才会启用主题字体；未命中时保留插件默认 CSS 和字体，但仍会继承主题包声明的背景与难度颜色。
 

--- a/resources/html/userinfo/userinfo-old.art
+++ b/resources/html/userinfo/userinfo-old.art
@@ -82,7 +82,7 @@
                         <p>{{e.tatle}}</p>
                     </div>
                     <div class="stats-up">
-                        <div class="Rating"> <img src="{{_res_path}}html/otherimg/{{e.Rating}}.png" alt="{{e.Rating}}">
+                        <div class="Rating"> <img src="{{themeInfo && themeInfo.icons && themeInfo.icons[e.Rating] ? themeInfo.icons[e.Rating] : (_res_path + 'html/otherimg/' + e.Rating + '.png')}}" alt="{{e.Rating}}">
                         </div>
                         <div class="stats-group">
                             <div class="stats-group-real">

--- a/resources/html/userinfo/userinfo.art
+++ b/resources/html/userinfo/userinfo.art
@@ -214,7 +214,7 @@
                     <p>{{e.title}}</p>
                 </div>
                 <div class="stats-up">
-                    <div class="Rating"> <img src="{{_res_path}}html/otherimg/{{e.Rating}}.png" alt="{{e.Rating}}">
+                    <div class="Rating"> <img src="{{themeInfo && themeInfo.icons && themeInfo.icons[e.Rating] ? themeInfo.icons[e.Rating] : (_res_path + 'html/otherimg/' + e.Rating + '.png')}}" alt="{{e.Rating}}">
                     </div>
                     <div class="stats-group">
                         <div class="stats-group-real">

--- a/tests/backgroundIllustration.test.js
+++ b/tests/backgroundIllustration.test.js
@@ -6,9 +6,9 @@ import getInfo from '../model/game/getInfo.js'
 test('SP个人背景曲绘通过内部ID解析', async () => {
     await getInfo.init()
 
-    assert.equal(getInfo.SongGetId('Introduction'), 'Introduction.0')
+    assert.equal(getInfo.SongGetId(/** @type {songString} */ ('Introduction')), 'Introduction.0')
     assert.equal(
-        getInfo.SongGetId('Oblivion:PHIN'),
+        getInfo.SongGetId(/** @type {songString} */ ('Oblivion:PHIN')),
         'OblivionPHIN.Daily天利vsEndCat终猫ftAiSSw夜輪.0'
     )
 

--- a/tests/backgroundIllustration.test.js
+++ b/tests/backgroundIllustration.test.js
@@ -3,18 +3,19 @@ import test from 'node:test'
 import fCompute from '../model/game/fCompute.js'
 import getInfo from '../model/game/getInfo.js'
 
-test('个人背景曲绘通过统一解析器获取', () => {
-    const original = getInfo.getBackground
-    const calls = []
-    getInfo.getBackground = background => {
-        calls.push(background)
-        return 'resolved-background.png'
-    }
+test('SP个人背景曲绘通过内部ID解析', async () => {
+    await getInfo.init()
 
-    try {
-        assert.equal(fCompute.getBackground('Introduction'), 'resolved-background.png')
-        assert.deepEqual(calls, ['Introduction'])
-    } finally {
-        getInfo.getBackground = original
-    }
+    assert.equal(getInfo.SongGetId('Introduction'), 'Introduction.0')
+    assert.equal(
+        getInfo.SongGetId('Oblivion:PHIN'),
+        'OblivionPHIN.Daily天利vsEndCat终猫ftAiSSw夜輪.0'
+    )
+
+    const result = fCompute.getBackground('Introduction')
+    if (!result) assert.fail('Introduction背景解析失败')
+
+    const background = result.replace(/\\/g, '/')
+    assert.match(background, /\/SP\/Introduction\.png$/)
+    assert.doesNotMatch(background, /\/otherimg\/phigros\.png$/)
 })

--- a/tests/saveStats.test.js
+++ b/tests/saveStats.test.js
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import Save from '../model/save/Save.js'
+import getInfo from '../model/game/getInfo.js'
+
+test('getStats does not count Legacy placeholders as AT unlocks', async () => {
+    const originalInfo = getInfo.ori_info
+    getInfo.ori_info = /** @type {any} */ ({
+        'regular-song.0': { chart: { AT: { difficulty: 15 } } },
+        'legacy-song.0': { chart: { LY: { difficulty: 15 } } },
+    })
+
+    try {
+        const stats = await Save.prototype.getStats.call({
+            gameRecord: {
+                'regular-song.0': [undefined, undefined, undefined, null],
+                'legacy-song.0': [undefined, undefined, undefined, null, { score: 1000000 }],
+            },
+        })
+
+        assert.equal(stats[3].tot, 1)
+        assert.equal(stats[3].unlock, 1)
+    } finally {
+        getInfo.ori_info = originalInfo
+    }
+})

--- a/tests/themeManager.test.js
+++ b/tests/themeManager.test.js
@@ -156,6 +156,79 @@ test('新版页面 CSS 优先匹配完整渲染目标，再回退到 app 短键'
     }
 })
 
+test('userinfo/userinfo 后置加载精确页面样式并使用主题图标', () => {
+    const testId = '__theme_userinfo__'
+    const testDir = path.join(THEMES_DIR, testId)
+    try {
+        fs.mkdirSync(testDir, { recursive: true })
+        fs.writeFileSync(path.join(testDir, 'info.yaml'), [
+            'id: "' + testId + '"',
+            'name: "User info"',
+            'css:',
+            '  userinfo/userinfo: "userinfo.css"',
+            'icon:',
+            '  FC: "FC.png"',
+            '',
+        ].join('\n'))
+        fs.writeFileSync(path.join(testDir, 'userinfo.css'), 'fixture')
+        fs.writeFileSync(path.join(testDir, 'FC.png'), 'fixture')
+        themeManager.scan()
+
+        const info = themeManager.getRenderInfo(testId, RES, 'userinfo/userinfo')
+        assert.ok(info)
+        assert.match(info.themeInfo.cssUrl, /__theme_userinfo__\/userinfo\.css$/)
+        assert.equal(info.themeInfo.cssMode, 'overlay')
+        assert.match(info.themeInfo.icons.FC, /__theme_userinfo__\/FC\.png$/)
+
+        const oldInfo = themeManager.getRenderInfo(testId, RES, 'userinfo/userinfo-old')
+        assert.ok(oldInfo)
+        assert.equal(oldInfo.themeInfo.cssUrl, undefined)
+
+        const source = fs.readFileSync(path.join(pluginResources, 'html', 'userinfo', 'userinfo.art'), 'utf8')
+        const html = art.render(source, {
+            _res_path: RES,
+            defaultLayout: path.join(pluginResources, 'html', 'common', 'layout', 'default.art'),
+            sys: { scale: 'style="transform:scale(1)"' },
+            theme: testId,
+            themeInfo: info.themeInfo,
+            background: undefined,
+            _plugin: 'phi-plugin',
+            Version: { ver: 'test' },
+            gameuser: {
+                avatar: 'avatar1',
+                backgroundurl: 'player.png',
+                PlayerId: 'TestPlayer',
+                rks: { toFixed: () => '15.0000' },
+                ChallengeMode: '0',
+                ChallengeModeRank: '12',
+                data: '100',
+                selfIntro: '',
+            },
+            rks_history: [],
+            data_history: [],
+            rks_range: [0, 0],
+            data_range: [0, 0],
+            data_date: [],
+            rks_date: [],
+            acc_rks_data: [],
+            acc_rks_range: [0, 0],
+            acc_rks_AccRange: [],
+            userstats: [{
+                Rating: 'FC', title: 'IN', unlock: 1, tot: 1, cleared: 1, fc: 1, phi: 1,
+                real_score: 1, tot_score: 1, highest: { toFixed: () => '15.00' },
+                lowest: { toFixed: () => '14.00' },
+            }],
+        })
+        assert.ok(html.includes('html/userinfo/userinfo.css'))
+        assert.ok(html.includes(info.themeInfo.cssUrl))
+        assert.ok(html.indexOf('html/userinfo/userinfo.css') < html.indexOf(info.themeInfo.cssUrl))
+        assert.ok(html.includes(info.themeInfo.icons.FC))
+    } finally {
+        fs.rmSync(testDir, { recursive: true, force: true })
+        themeManager.scan()
+    }
+})
+
 test('旧版字符串 css 仅替换 B19 样式，其他页面使用默认 CSS 和字体', () => {
     const testId = '__theme_legacy_css__'
     const testDir = path.join(THEMES_DIR, testId)

--- a/tests/themeManager.test.js
+++ b/tests/themeManager.test.js
@@ -20,6 +20,45 @@ async function waitFor(fn, timeout = 4000) {
     return fn()
 }
 
+/** @param {string} theme @param {any} themeInfo @param {string} [template] */
+function renderUserInfo(theme, themeInfo, template = 'userinfo') {
+    const source = fs.readFileSync(path.join(pluginResources, 'html', 'userinfo', `${template}.art`), 'utf8')
+    return art.render(source, {
+        _res_path: RES,
+        defaultLayout: path.join(pluginResources, 'html', 'common', 'layout', 'default.art'),
+        sys: { scale: 'style="transform:scale(1)"' },
+        theme,
+        themeInfo,
+        background: 'song.png',
+        _plugin: 'phi-plugin',
+        Version: { ver: 'test' },
+        gameuser: {
+            avatar: 'avatar1',
+            backgroundurl: 'player.png',
+            PlayerId: 'TestPlayer',
+            rks: { toFixed: () => '15.0000' },
+            ChallengeMode: '0',
+            ChallengeModeRank: '12',
+            data: '100',
+            selfIntro: '',
+        },
+        rks_history: [],
+        data_history: [],
+        rks_range: [0, 0],
+        data_range: [0, 0],
+        data_date: [],
+        rks_date: [],
+        acc_rks_data: [],
+        acc_rks_range: [0, 0],
+        acc_rks_AccRange: [],
+        userstats: [{
+            Rating: 'FC', title: 'IN', unlock: 1, tot: 1, cleared: 1, fc: 1, phi: 1,
+            real_score: 1, tot_score: 1, highest: { toFixed: () => '15.00' },
+            lowest: { toFixed: () => '14.00' },
+        }],
+    })
+}
+
 test('内置主题注册完整，milthm 作为自定义主题注册成功', () => {
     assert.ok(themeManager.isTheme('default'))
     assert.ok(themeManager.isTheme('snow'))
@@ -184,41 +223,7 @@ test('userinfo/userinfo 后置加载精确页面样式并使用主题图标', ()
         assert.ok(oldInfo)
         assert.equal(oldInfo.themeInfo.cssUrl, undefined)
 
-        const source = fs.readFileSync(path.join(pluginResources, 'html', 'userinfo', 'userinfo.art'), 'utf8')
-        const html = art.render(source, {
-            _res_path: RES,
-            defaultLayout: path.join(pluginResources, 'html', 'common', 'layout', 'default.art'),
-            sys: { scale: 'style="transform:scale(1)"' },
-            theme: testId,
-            themeInfo: info.themeInfo,
-            background: undefined,
-            _plugin: 'phi-plugin',
-            Version: { ver: 'test' },
-            gameuser: {
-                avatar: 'avatar1',
-                backgroundurl: 'player.png',
-                PlayerId: 'TestPlayer',
-                rks: { toFixed: () => '15.0000' },
-                ChallengeMode: '0',
-                ChallengeModeRank: '12',
-                data: '100',
-                selfIntro: '',
-            },
-            rks_history: [],
-            data_history: [],
-            rks_range: [0, 0],
-            data_range: [0, 0],
-            data_date: [],
-            rks_date: [],
-            acc_rks_data: [],
-            acc_rks_range: [0, 0],
-            acc_rks_AccRange: [],
-            userstats: [{
-                Rating: 'FC', title: 'IN', unlock: 1, tot: 1, cleared: 1, fc: 1, phi: 1,
-                real_score: 1, tot_score: 1, highest: { toFixed: () => '15.00' },
-                lowest: { toFixed: () => '14.00' },
-            }],
-        })
+        const html = renderUserInfo(testId, info.themeInfo)
         assert.ok(html.includes('html/userinfo/userinfo.css'))
         assert.ok(html.includes(info.themeInfo.cssUrl))
         assert.ok(html.indexOf('html/userinfo/userinfo.css') < html.indexOf(info.themeInfo.cssUrl))
@@ -226,6 +231,28 @@ test('userinfo/userinfo 后置加载精确页面样式并使用主题图标', ()
     } finally {
         fs.rmSync(testDir, { recursive: true, force: true })
         themeManager.scan()
+    }
+})
+
+test('userinfo 未配置专用样式时保留原生 CSS、主题背景和主题评级图标', () => {
+    for (const template of ['userinfo', 'userinfo-old']) {
+        const target = `userinfo/${template}`
+        const info = themeManager.getRenderInfo('milthm', RES, target)
+        assert.ok(info)
+        assert.equal(info.themeInfo.cssUrl, undefined)
+        assert.equal(info.themeInfo.fontUrl, undefined)
+        assert.ok(info.themeInfo.backgroundUrl)
+        assert.ok(info.themeInfo.icons.FC)
+
+        const html = renderUserInfo('milthm', info.themeInfo, template)
+        assert.ok(html.includes(`html/userinfo/${template}.css`))
+        assert.ok(html.includes(info.themeInfo.backgroundUrl))
+        assert.ok(html.includes(info.themeInfo.icons.FC))
+        assert.ok(!html.includes('@font-face'))
+        assert.ok(!html.includes('font-family: "phi-theme"'))
+
+        const defaultIconHtml = renderUserInfo('milthm', { ...info.themeInfo, icons: {} }, template)
+        assert.ok(defaultIconHtml.includes('html/otherimg/FC.png'))
     }
 })
 

--- a/tests/themePageRouting.test.js
+++ b/tests/themePageRouting.test.js
@@ -2,11 +2,14 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { phihelp as ApiSettings } from '../apps/apiSetting.js'
 import { phihelp as UserSettings } from '../apps/setting.js'
+import { phiuser as UserInfo } from '../apps/user.js'
 import getInfo from '../model/game/getInfo.js'
+import fCompute from '../model/game/fCompute.js'
 import picmodle from '../model/render/picmodle.js'
 import send from '../model/render/send.js'
 import getBanGroup from '../model/user/getBanGroup.js'
 import getNotes from '../model/user/getNotes.js'
+import { UserCredentials } from '../model/user/userCredentials.js'
 
 /** @param {string} msg */
 const event = msg => ({
@@ -95,5 +98,91 @@ test('API 用户设置页把当前主题传给完整页面渲染目标', async (
         getInfo.getill = originals.getIll
         picmodle.common = originals.common
         send.send_with_At = originals.send
+    }
+})
+
+test('info 命令传递用户主题并正确区分新版和旧版渲染', async () => {
+    const originals = {
+        getBan: getBanGroup.get,
+        getNotesData: getNotes.getNotesData,
+        getIll: getInfo.getill,
+        fuzzySongsNick: getInfo.fuzzysongsnick,
+        getAvatar: getInfo.idgetavatar,
+        getBackground: fCompute.getBackground,
+        getSave: send.getsave_result,
+        send: send.send_with_At,
+        userInfo: picmodle.user_info,
+        fromEvent: UserCredentials.fromEvent,
+    }
+    /** @type {any[]} */ const renders = []
+    const history = {
+        getRksAndDataLine: () => ({
+            rks_history: [],
+            data_history: [],
+            rks_range: [0, 0],
+            data_range: [0, 0],
+            rks_date: [new Date(0), new Date(0)],
+            data_date: [new Date(0), new Date(0)],
+        }),
+    }
+    const save = {
+        getStats: async () => [],
+        getRecord: () => [],
+        findAccRecord: () => [],
+        gameProgress: { money: [0, 0, 0, 0, 0] },
+        gameuser: { avatar: 'avatar-id', background: 'song-id', selfIntro: 'hello' },
+        saveInfo: {
+            PlayerId: 'TestPlayer',
+            summary: { challengeModeRank: 312, rankingScore: 15.1234 },
+        },
+    }
+
+    getBanGroup.get = async () => false
+    getNotes.getNotesData = async () => /** @type {any} */ ({ theme: 'milthm', allowApiUsage: false })
+    getInfo.getill = () => 'background.png'
+    getInfo.fuzzysongsnick = /** @type {any} */ (() => ['song-id'])
+    getInfo.idgetavatar = () => 'avatar1'
+    fCompute.getBackground = () => 'player-background.png'
+    send.getsave_result = /** @type {any} */ (async () => save)
+    send.send_with_At = /** @type {any} */ (async () => undefined)
+    picmodle.user_info = /** @type {any} */ (async (/** @type {any} */ e, /** @type {any} */ data, /** @type {any} */ kind) => {
+        renders.push({ e, data, kind })
+        return 'image'
+    })
+    UserCredentials.fromEvent = /** @type {any} */ (() => ({
+        getLocalHistory: async () => history,
+        getCloudHistory: async () => history,
+    }))
+
+    try {
+        const command = new UserInfo()
+        /** @type {Array<[string, number]>} */
+        const cases = [
+            ['/phi info', 0],
+            ['/phi info1', 1],
+            ['/phi info2', 2],
+            ['#phi info2', 2],
+            ['/phiinfo2', 2],
+            ['/phi info2 Test Song', 2],
+        ]
+        for (const [message, expectedKind] of cases) {
+            await command.info(/** @type {any} */ (event(message)))
+            const render = renders.at(-1)
+            assert.ok(render)
+            assert.equal(render.data.theme, 'milthm')
+            assert.equal(render.kind, expectedKind)
+        }
+        assert.equal(renders.length, cases.length)
+    } finally {
+        getBanGroup.get = originals.getBan
+        getNotes.getNotesData = originals.getNotesData
+        getInfo.getill = originals.getIll
+        getInfo.fuzzysongsnick = originals.fuzzySongsNick
+        getInfo.idgetavatar = originals.getAvatar
+        fCompute.getBackground = originals.getBackground
+        send.getsave_result = originals.getSave
+        send.send_with_At = originals.send
+        picmodle.user_info = originals.userInfo
+        UserCredentials.fromEvent = originals.fromEvent
     }
 })


### PR DESCRIPTION
## 概述

合并 PR #345、PR #346，并补充 AT 解锁统计修复，完善自定义主题在用户信息页的支持，同时修复 SP 背景曲绘解析和 Arc B30 页面布局问题。

## 主要变更

### 用户信息页主题支持

- 支持为 `userinfo/userinfo` 和 `userinfo/userinfo-old` 配置专用主题样式。
- `/info`、`/info1`、`/info2` 正确传递当前用户主题。
- 支持新版和旧版用户信息页使用主题评级图标。
- 页面 CSS 按完整渲染目标优先匹配，缺少专用样式时回退到官方默认 CSS。
- 自定义主题未配置页面字体时，不会污染官方默认字体和页面布局。
- 主题资源缺失时保留官方背景、评级图标和默认资源作为 fallback。
- 补充自定义主题页面配置文档和路由测试。

### SP 背景曲绘与 Arc B30

- 补全 SP 曲目原始键和显示名称到内部 ID 的映射。
- 修复 SP 个人背景曲绘被错误回退到通用背景的问题。
- 左移 Arc B30 生成时间区域，避免与顶部内容重叠。
- 增加 SP 背景解析回归测试。

### AT 解锁统计

- 统计存档解锁数时，以当前曲库中实际存在的谱面和有效定数为准。
- 修复 Legacy 记录数组下标 3 的 `null` 占位被误计为 AT 解锁的问题。
- 保留真实 AT 谱面的 `null` 解锁状态统计。
- 新增 AT 与 Legacy 对照回归测试。

### 类型约束

- 恢复 `idssong` 的 branded `songString` 索引类型。
- 恢复 `SongGetId(songString)` 参数约束。
- 仅在读取 SP 原始数据的边界处进行显式类型转换，不改变运行时行为。
